### PR TITLE
quadcontrol: fix PID calculations

### DIFF
--- a/quadcontrol/pid.c
+++ b/quadcontrol/pid.c
@@ -33,13 +33,16 @@ float pid_calc(pid_ctx_t *pid, float setVal, float currVal, float dt)
 	err = setVal - currVal;
 
 	/* Derivative */
-	d = (err - pid->prevErr) / dt;
+	d =(pid->kd * (err - pid->prevErr)) / dt;
 
 	/* Proportional */
-	p = err * pid->kp;
+	p = pid->kp * err;
 
 	/* Integral */
-	i = pid->integral + (err * dt);
+	i = pid->integral + pid->ki * (err * dt);
+	if (i > pid->maxInteg) {
+		i = pid->maxInteg;
+	}
 
 	/* PID */
 	out = p + i + d;
@@ -51,6 +54,7 @@ float pid_calc(pid_ctx_t *pid, float setVal, float currVal, float dt)
 		out = pid->min;
 	}
 
+	pid->integral = i;
 	pid->prevErr = err;
 	pid->lastPid = out;
 

--- a/quadcontrol/pid.h
+++ b/quadcontrol/pid.h
@@ -17,13 +17,14 @@
 
 typedef struct {
 	/* Coefficients */
-	float kp;      /* proportional gain */
-	float ki;      /* integral gain */
-	float kd;      /* derivative gain */
+	float kp; /* proportional gain */
+	float ki; /* integral gain */
+	float kd; /* derivative gain */
 
 	/* PID limits */
-	float max; /* Maximum allowed PID value */
-	float min; /* Minimum allowed PID value */
+	float max;      /* Maximum allowed PID value */
+	float min;      /* Minimum allowed PID value */
+	float maxInteg; /* Maximum integral value */
 
 	float integral; /* Accumulate for integral term */
 	float prevErr;  /* Previous error */


### PR DESCRIPTION
- add missing gains in D and I
- add maximum value for integral part of PID

PP-22