### PR TITLE
ci: add linter

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,29 @@
+---
+BasedOnStyle: WebKit
+
+ColumnLimit: 0
+AlignAfterOpenBracket: DontAlign
+UseTab: ForContinuationAndIndentation
+IndentWidth: 4
+ContinuationIndentWidth: 4
+TabWidth: 4
+
+PointerAlignment: Right
+SpaceAfterCStyleCast: 'false'
+BreakBeforeBraces: Stroustrup
+
+AlignConsecutiveMacros: 'true'
+AlignEscapedNewlines: DontAlign
+AlignTrailingComments: 'true'
+AllowShortBlocksOnASingleLine: 'true'
+AllowShortCaseLabelsOnASingleLine: 'true'
+AllowShortLoopsOnASingleLine: 'true'
+IndentCaseLabels: 'true'
+MaxEmptyLinesToKeep: 2
+SortIncludes: 'false'
+SpacesBeforeTrailingComments: 2
+
+BreakBeforeBinaryOperators: None
+BreakBeforeTernaryOperators: 'false'
+BreakConstructorInitializers: AfterColon
+...

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!--- Describe your changes shortly -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## Types of changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+- [ ] Already covered by automatic testing.
+- [ ] New test added: (add PR link here).
+- [ ] Tested by hand on: (list targets here).
+
+## Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [ ] I have added tests to cover my changes.
+- [ ] All new and existing linter checks and tests passed.
+- [ ] My changes generate no new compilation warnings for any of the targets.
+
+## Special treatment
+
+- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
+- [ ] I will merge this PR by myself when appropriate.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,16 @@
+name: ci
+
+# on events
+on:
+  push:
+    branches:
+      - main
+      - 'feature/*'
+  pull_request:
+    branches:
+      - main
+      - 'feature/*'
+
+jobs:
+  call-ci:
+    uses: phoenix-pilot/phoenix-pilot-project/.github/workflows/lint.yml@master


### PR DESCRIPTION
This PR adds basic linter, it works the same as the `phoenix-project` template project.