### PR TITLE
ekf: ekflib returns fix + treat barometer height as altitude

### DIFF
--- a/ekf/ekflib.c
+++ b/ekf/ekflib.c
@@ -138,5 +138,6 @@ void ekf_stateGet(ekf_state_t *ekf_state)
 	/* save position */
 	ekf_state->enuX = ekf_common.stateEngine.state.data[ixx];
 	ekf_state->enuY = ekf_common.stateEngine.state.data[ixy];
-	ekf_state->enuZ = ekf_common.stateEngine.state.data[ixz];
+	/* as long as inertial reckoning is not trustable enough, return barometer height as enuZ */
+	ekf_state->enuZ = ekf_common.stateEngine.state.data[ihz];
 }

--- a/ekf/ekflib.c
+++ b/ekf/ekflib.c
@@ -101,7 +101,6 @@ static void ekf_thread(void *arg)
 		}
 	}
 
-	printf("ekf: ekf thread stopped!\n");
 	ekf_common.run = -1;
 	endthread();
 }
@@ -138,6 +137,6 @@ void ekf_stateGet(ekf_state_t *ekf_state)
 
 	/* save position */
 	ekf_state->enuX = ekf_common.stateEngine.state.data[ixx];
-	ekf_state->enuX = ekf_common.stateEngine.state.data[ixy];
-	ekf_state->enuX = ekf_common.stateEngine.state.data[ixz];
+	ekf_state->enuY = ekf_common.stateEngine.state.data[ixy];
+	ekf_state->enuZ = ekf_common.stateEngine.state.data[ixz];
 }

--- a/ekf/kalman_implem.c
+++ b/ekf/kalman_implem.c
@@ -38,7 +38,7 @@ kalman_init_t init_values = {
 	.P_merr = 300,             /* 300 uT */
 	.P_qaerr = 10 * DEG2RAD,   /* 10 degrees */
 	.P_qijkerr = 10 * DEG2RAD, /* 10 degrees */
-	.P_pxerr = 10,             /* 10 hPa */
+	.P_pxerr = 0.01,           /* 10 hPa */
 
 	.R_acov = 0.001,
 	.R_wcov = 0.01,
@@ -48,13 +48,13 @@ kalman_init_t init_values = {
 	.R_pcov = 0.1,
 	.R_hcov = 1,
 	.R_xzcov = 1,
-	.R_hvcov = 1,
+	.R_hvcov = 0.1,
 	.R_vzcov = 2,
 
 	/* better to keep Q low */
 	.Q_xcov = 0.001,
 	.Q_vcov = 0.001,
-	.Q_hcov = 0.01,
+	.Q_hcov = 0.001,
 	.Q_avertcov = 0.0001,
 	.Q_ahoricov = 0.0001,
 	.Q_wcov = 0.0001,
@@ -237,7 +237,7 @@ static void calcPredictionJacobian(phmatrix_t *F, phmatrix_t *state, time_t time
 	float I33_data[9] = { 0 };
 	phmatrix_t I33 = { .rows = 3, .cols = 3, .transposed = 0, .data = I33_data };
 
-	dt = timeStep / 1000000.;
+	dt = timeStep / 1000000.F;
 	dt2 = dt / 2; /* helper value */
 
 	/* derrivative submatrix of (dfq / dq) of size 4x4 */

--- a/ekf/kalman_update_baro.c
+++ b/ekf/kalman_update_baro.c
@@ -109,8 +109,10 @@ static phmatrix_t *getMeasurement(phmatrix_t *Z, phmatrix_t *state, phmatrix_t *
 	phx_zeroes(Z);
 	Z->data[imhz] = 8453.669 * log(meas_calibPressGet() / pressure);
 	Z->data[imxz] = 0.8 * hz + 0.2 * xz;
-	Z->data[imhv] = filterBaroSpeed();
-	Z->data[imvz] = hv;
+
+	/* vertical speed fusion turned off. Intentionally left as zeroes */
+	Z->data[imhv] = 0;
+	Z->data[imvz] = 0;
 
 	return Z;
 }

--- a/ekf/measurement.c
+++ b/ekf/measurement.c
@@ -35,7 +35,7 @@
 #define EARTH_ECCENTRICITY_SQUARED 0.006694384F
 
 #define IMU_CALIB_AVG  200
-#define BARO_CALIB_AVG 10
+#define BARO_CALIB_AVG 100
 
 static struct {
 	kalman_calib_t calib;
@@ -261,7 +261,7 @@ void meas_baroCalib(void)
 			press += baroEvt.baro.pressure;
 			temp += baroEvt.baro.temp;
 			i++;
-			usleep(1000 * 50);
+			usleep(1000 * 20);
 		}
 		else {
 			usleep(1000 * 10);

--- a/ekf/tests/devekf.c
+++ b/ekf/tests/devekf.c
@@ -46,6 +46,7 @@ int main(int argc, char **argv)
 		usleep(1000 * 100);
 		ekf_stateGet(&uavState);
 		q = (quat_t) { .a = uavState.q0, .i = uavState.q1, .j = uavState.q2, .k = uavState.q3 };
+		start = (vec_t) { .x = uavState.enuX, .y = uavState.enuY, .z = uavState.enuZ };
 		printUavVersors(&q, &start);
 		i++;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
 - fixed typos in ekflib.c leading to only X position being saved
 - removed ekf thread end log that sometimes crashes the thread
 - ekf barometer measurement changes
   - barometer speed not fused into state
   - ekf returns barometer height as enuZ altitude

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
