### PR TITLE
AHRS: Improve accelerometer noise handling

### DIFF
--- a/ekf/Makefile
+++ b/ekf/Makefile
@@ -21,3 +21,8 @@ LOCAL_SRCS := tests/devekf.c
 DEP_LIBS := libekf
 LOCAL_LDFLAGS := -z stack-size=16096 -z noexecstack
 include $(binary.mk)
+
+NAME := sensortest
+LOCAL_SRCS := tests/sensortest.c
+DEP_LIBS := libekf
+include $(binary.mk)

--- a/ekf/ekflib.c
+++ b/ekf/ekflib.c
@@ -125,7 +125,7 @@ void ekf_done(void)
 void ekf_stateGet(ekf_state_t *ekf_state)
 {
 	quat_t q;
-	vec_t angRates = { 0 }; /* (roll_dot, pitch_dot, yaw_dot) */
+	vec_t angRates = { 0 }; /* (rollDot, pitchDot, yawDot) */
 
 	/* save quaternion attitude */
 	q.a = ekf_state->q0 = ekf_common.stateEngine.state.data[iqa];
@@ -152,7 +152,7 @@ void ekf_stateGet(ekf_state_t *ekf_state)
 	angRates.z = ekf_common.stateEngine.state.data[iwz];
 	quat_cjg(&q);
 	quat_vecRot(&angRates, &q);
-	ekf_state->roll_dot = angRates.x;
-	ekf_state->pitch_dot = angRates.y;
-	ekf_state->yaw_dot = angRates.z;
+	ekf_state->rollDot = angRates.x;
+	ekf_state->pitchDot = angRates.y;
+	ekf_state->yawDot = angRates.z;
 }

--- a/ekf/ekflib.c
+++ b/ekf/ekflib.c
@@ -122,29 +122,29 @@ void ekf_done(void)
 }
 
 
-void ekf_stateGet(ekf_state_t *ekf_state)
+void ekf_stateGet(ekf_state_t *ekfState)
 {
 	quat_t q;
 	vec_t angRates = { 0 }; /* (rollDot, pitchDot, yawDot) */
 
 	/* save quaternion attitude */
-	q.a = ekf_state->q0 = ekf_common.stateEngine.state.data[iqa];
-	q.i = ekf_state->q1 = ekf_common.stateEngine.state.data[iqb];
-	q.j = ekf_state->q2 = ekf_common.stateEngine.state.data[iqc];
-	q.k = ekf_state->q3 = ekf_common.stateEngine.state.data[iqd];
+	q.a = ekfState->q0 = ekf_common.stateEngine.state.data[iqa];
+	q.i = ekfState->q1 = ekf_common.stateEngine.state.data[iqb];
+	q.j = ekfState->q2 = ekf_common.stateEngine.state.data[iqc];
+	q.k = ekfState->q3 = ekf_common.stateEngine.state.data[iqd];
 
 	/* calculate and save euler attitude */
-	quat_quat2euler(&q, &ekf_state->roll, &ekf_state->pitch, &ekf_state->yaw);
+	quat_quat2euler(&q, &ekfState->roll, &ekfState->pitch, &ekfState->yaw);
 
 	/* save position */
-	ekf_state->enuX = ekf_common.stateEngine.state.data[ixx];
-	ekf_state->enuY = ekf_common.stateEngine.state.data[ixy];
+	ekfState->enuX = ekf_common.stateEngine.state.data[ixx];
+	ekfState->enuY = ekf_common.stateEngine.state.data[ixy];
 	/* as long as inertial reckoning is not trustable enough, return barometer height as enuZ */
-	ekf_state->enuZ = ekf_common.stateEngine.state.data[ihz];
+	ekfState->enuZ = ekf_common.stateEngine.state.data[ihz];
 
-	ekf_state->accelX = ekf_common.stateEngine.state.data[iax];
-	ekf_state->accelY = ekf_common.stateEngine.state.data[iay];
-	ekf_state->accelZ = ekf_common.stateEngine.state.data[iaz];
+	ekfState->accelX = ekf_common.stateEngine.state.data[iax];
+	ekfState->accelY = ekf_common.stateEngine.state.data[iay];
+	ekfState->accelZ = ekf_common.stateEngine.state.data[iaz];
 
 	/* rotate angular rated back to UAV frame of reference */
 	angRates.x = ekf_common.stateEngine.state.data[iwx];
@@ -152,7 +152,7 @@ void ekf_stateGet(ekf_state_t *ekf_state)
 	angRates.z = ekf_common.stateEngine.state.data[iwz];
 	quat_cjg(&q);
 	quat_vecRot(&angRates, &q);
-	ekf_state->rollDot = angRates.x;
-	ekf_state->pitchDot = angRates.y;
-	ekf_state->yawDot = angRates.z;
+	ekfState->rollDot = angRates.x;
+	ekfState->pitchDot = angRates.y;
+	ekfState->yawDot = angRates.z;
 }

--- a/ekf/ekflib.c
+++ b/ekf/ekflib.c
@@ -142,6 +142,10 @@ void ekf_stateGet(ekf_state_t *ekf_state)
 	/* as long as inertial reckoning is not trustable enough, return barometer height as enuZ */
 	ekf_state->enuZ = ekf_common.stateEngine.state.data[ihz];
 
+	ekf_state->accelX = ekf_common.stateEngine.state.data[iax];
+	ekf_state->accelY = ekf_common.stateEngine.state.data[iay];
+	ekf_state->accelZ = ekf_common.stateEngine.state.data[iaz];
+
 	/* rotate angular rated back to UAV frame of reference */
 	angRates.x = ekf_common.stateEngine.state.data[iwx];
 	angRates.y = ekf_common.stateEngine.state.data[iwy];
@@ -151,5 +155,4 @@ void ekf_stateGet(ekf_state_t *ekf_state)
 	ekf_state->roll_dot = angRates.x;
 	ekf_state->pitch_dot = angRates.y;
 	ekf_state->yaw_dot = angRates.z;
-
 }

--- a/ekf/ekflib.c
+++ b/ekf/ekflib.c
@@ -125,6 +125,7 @@ void ekf_done(void)
 void ekf_stateGet(ekf_state_t *ekf_state)
 {
 	quat_t q;
+	vec_t angRates = { 0 }; /* (roll_dot, pitch_dot, yaw_dot) */
 
 	/* save quaternion attitude */
 	q.a = ekf_state->q0 = ekf_common.stateEngine.state.data[iqa];
@@ -140,4 +141,15 @@ void ekf_stateGet(ekf_state_t *ekf_state)
 	ekf_state->enuY = ekf_common.stateEngine.state.data[ixy];
 	/* as long as inertial reckoning is not trustable enough, return barometer height as enuZ */
 	ekf_state->enuZ = ekf_common.stateEngine.state.data[ihz];
+
+	/* rotate angular rated back to UAV frame of reference */
+	angRates.x = ekf_common.stateEngine.state.data[iwx];
+	angRates.y = ekf_common.stateEngine.state.data[iwy];
+	angRates.z = ekf_common.stateEngine.state.data[iwz];
+	quat_cjg(&q);
+	quat_vecRot(&angRates, &q);
+	ekf_state->roll_dot = angRates.x;
+	ekf_state->pitch_dot = angRates.y;
+	ekf_state->yaw_dot = angRates.z;
+
 }

--- a/ekf/include/ekflib.h
+++ b/ekf/include/ekflib.h
@@ -30,6 +30,11 @@ typedef struct {
 	float q1;
 	float q2;
 	float q3;
+
+	/* angular rates in uav frame of reference */
+	float pitch_dot;
+	float yaw_dot;
+	float roll_dot;
 } ekf_state_t;
 
 extern int ekf_init(void);

--- a/ekf/include/ekflib.h
+++ b/ekf/include/ekflib.h
@@ -32,9 +32,9 @@ typedef struct {
 	float q3;
 
 	/* angular rates in uav frame of reference */
-	float pitch_dot;
-	float yaw_dot;
-	float roll_dot;
+	float pitchDot;
+	float yawDot;
+	float rollDot;
 
 	/* accelerations in earth frame of reference */
 	float accelX;

--- a/ekf/include/ekflib.h
+++ b/ekf/include/ekflib.h
@@ -35,6 +35,11 @@ typedef struct {
 	float pitch_dot;
 	float yaw_dot;
 	float roll_dot;
+
+	/* accelerations in earth frame of reference */
+	float accelX;
+	float accelY;
+	float accelZ;
 } ekf_state_t;
 
 extern int ekf_init(void);

--- a/ekf/kalman_implem.c
+++ b/ekf/kalman_implem.c
@@ -40,7 +40,7 @@ kalman_init_t init_values = {
 	.P_qijkerr = 10 * DEG2RAD, /* 10 degrees */
 	.P_pxerr = 0.01,           /* 10 hPa */
 
-	.R_acov = 0.001,
+	.R_acov = 0.1,
 	.R_wcov = 0.01,
 	.R_mcov = 10,
 	.R_qcov = 0.1,

--- a/ekf/kalman_update_baro.c
+++ b/ekf/kalman_update_baro.c
@@ -37,8 +37,7 @@ extern kalman_init_t init_values;
 /* barometric height memory */
 static float baroMemory[2][6] = { 0 };
 
-enum baroDimension { value = 0,
-	dtime = 1 };
+enum baroDimension { value = 0, dtime = 1 };
 
 static int memoryPoint = 0;
 

--- a/ekf/measurement.c
+++ b/ekf/measurement.c
@@ -34,7 +34,7 @@
 #define EARTH_SEMI_MINOR           6356752.3F
 #define EARTH_ECCENTRICITY_SQUARED 0.006694384F
 
-#define IMU_CALIB_AVG  200
+#define IMU_CALIB_AVG  1000
 #define BARO_CALIB_AVG 100
 
 static struct {
@@ -225,6 +225,9 @@ void meas_imuCalib(void)
 			meas_gyr2si(&gyrEvt, &gyr);
 			meas_mag2si(&magEvt, &mag);
 
+			meas_ellipCompensate(&acc, acc_calib1);
+			meas_ellipCompensate(&mag, mag_calib1);
+
 			vec_add(&accAvg, &acc);
 			vec_add(&gyrAvg, &gyr);
 			vec_add(&magAvg, &mag);
@@ -243,6 +246,8 @@ void meas_imuCalib(void)
 	meas_common.calib.init_m = magAvg;    /* save initial magnetometer reading */
 
 	/* calculate initial rotation */
+	vec_normalize(&accAvg);
+	vec_normalize(&magAvg);
 	vec_cross(&accAvg, &magAvg, &n);
 	quat_frameRot(&accAvg, &n, &gvec, &versorX, &meas_common.calib.init_q, &idenQuat);
 }

--- a/ekf/sensc.c
+++ b/ekf/sensc.c
@@ -26,9 +26,7 @@
 
 #define SENSORHUB_PIPES 3 /* number of connections with sensorhub */
 
-typedef enum { fd_imuId = 0,
-	fd_baroId,
-	fd_gpsId } fd_id_t;
+typedef enum { fd_imuId = 0, fd_baroId, fd_gpsId } fd_id_t;
 
 struct {
 	sensors_data_t *data;

--- a/ekf/tests/devekf.c
+++ b/ekf/tests/devekf.c
@@ -39,13 +39,13 @@ static void printUavVersors(ekf_state_t *uavState)
 }
 
 
-static void printUavAtt(ekf_state_t *uavState)
+static inline void printUavAtt(ekf_state_t *uavState)
 {
 	printf("YPR: %f %f %f YPR_DOT %f %f %f\n", uavState->yaw * 180 / 3.1415, uavState->pitch * 180 / 3.1415, uavState->roll * 180 / 3.1415, uavState->yawDot, uavState->pitchDot, uavState->rollDot);
 }
 
 
-static void printUavAcc(ekf_state_t *uavState)
+static inline void printUavAcc(ekf_state_t *uavState)
 {
 	printf("XYZ %f %f %f\n", uavState->accelX, uavState->accelY, uavState->accelZ);
 }
@@ -56,13 +56,16 @@ int main(int argc, char **argv)
 	ekf_state_t uavState;
 	enum printMode mode = prntVersor;
 
-	if (argc > 1) {
-		if (atoi(argv[1]) == 1) {
-			mode = prntAtt;
-		}
-		if (atoi(argv[1]) == 2) {
-			mode = printAcc;
-		}
+	if (argc != 2) {
+		printf("Wrong arguments count!\n");
+		return EXIT_FAILURE;
+	}
+
+	if (atoi(argv[1]) == 1) {
+		mode = prntAtt;
+	}
+	if (atoi(argv[1]) == 2) {
+		mode = printAcc;
 	}
 
 	if (ekf_init() == 0) {
@@ -86,5 +89,5 @@ int main(int argc, char **argv)
 
 	ekf_done();
 
-	return 0;
+	return EXIT_SUCCESS;
 }

--- a/ekf/tests/devekf.c
+++ b/ekf/tests/devekf.c
@@ -41,7 +41,7 @@ static void printUavVersors(ekf_state_t *uavState)
 
 static void printUavAtt(ekf_state_t *uavState)
 {
-	printf("YPR: %f %f %f YPR_DOT %f %f %f\n", uavState->yaw * 180 / 3.1415, uavState->pitch * 180 / 3.1415, uavState->roll * 180 / 3.1415, uavState->yaw_dot, uavState->pitch_dot, uavState->roll_dot);
+	printf("YPR: %f %f %f YPR_DOT %f %f %f\n", uavState->yaw * 180 / 3.1415, uavState->pitch * 180 / 3.1415, uavState->roll * 180 / 3.1415, uavState->yawDot, uavState->pitchDot, uavState->rollDot);
 }
 
 

--- a/ekf/tests/devekf.c
+++ b/ekf/tests/devekf.c
@@ -15,14 +15,21 @@
 
 #include <stdio.h>
 #include <unistd.h>
+#include <stdlib.h>
 
 #include <ekflib.h>
 
 #include "../tools/rotas_dummy.h"
 
-static void printUavVersors(quat_t *q, vec_t *start)
+
+enum printMode { prntVersor, prntAtt };
+
+
+static void printUavVersors(ekf_state_t *uavState)
 {
+	vec_t start = { .x = uavState->enuX, .y = uavState->enuY, .z = uavState->enuZ };
 	vec_t x = { .x = 1, .y = 0, .z = 0 }, y = { .x = 0, .y = 1, .z = 0 }, z = { .x = 0, .y = 0, .z = 1 };
+	quat_t q = { .a = uavState->q0, .i = uavState->q1, .j = uavState->q2, .k = uavState->q3 };
 
 	quat_vecRot(&x, q);
 	quat_vecRot(&y, q);
@@ -31,12 +38,26 @@ static void printUavVersors(quat_t *q, vec_t *start)
 	printf("%.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f\n", x.x, x.y, x.z, y.x, y.y, y.z, z.x, z.y, z.z, start->x, start->y, start->z);
 }
 
+
+static void printUavAtt(ekf_state_t *uavState)
+{
+	printf("YPR: %f %f %f YPR_DOT %f %f %f\n", uavState->yaw,  uavState->pitch,  uavState->roll, uavState->yaw_dot,  uavState->pitch_dot,  uavState->roll_dot);
+}
+
+
 int main(int argc, char **argv)
 {
 	ekf_state_t uavState;
-	quat_t q;
+
 	vec_t start = { 0 };
 	int i = 0;
+	enum printMode mode = prntVersor;
+
+	if (argc > 1) {
+		if (atoi(argv[1]) == 1) {
+			mode = prntAtt;
+		}
+	}
 
 	if (ekf_init() == 0) {
 		ekf_run();
@@ -45,9 +66,12 @@ int main(int argc, char **argv)
 	while (i < 1000) {
 		usleep(1000 * 100);
 		ekf_stateGet(&uavState);
-		q = (quat_t) { .a = uavState.q0, .i = uavState.q1, .j = uavState.q2, .k = uavState.q3 };
-		start = (vec_t) { .x = uavState.enuX, .y = uavState.enuY, .z = uavState.enuZ };
-		printUavVersors(&q, &start);
+		if (mode == prntVersor) {
+			printUavVersors(&uavState);
+		}
+		if (mode == prntAtt) {
+			printUavAtt(&uavState);
+		}
 		i++;
 	}
 

--- a/ekf/tests/devekf.c
+++ b/ekf/tests/devekf.c
@@ -22,7 +22,7 @@
 #include "../tools/rotas_dummy.h"
 
 
-enum printMode { prntVersor, prntAtt };
+enum printMode { prntVersor, prntAtt, printAcc };
 
 
 static void printUavVersors(ekf_state_t *uavState)
@@ -31,31 +31,37 @@ static void printUavVersors(ekf_state_t *uavState)
 	vec_t x = { .x = 1, .y = 0, .z = 0 }, y = { .x = 0, .y = 1, .z = 0 }, z = { .x = 0, .y = 0, .z = 1 };
 	quat_t q = { .a = uavState->q0, .i = uavState->q1, .j = uavState->q2, .k = uavState->q3 };
 
-	quat_vecRot(&x, q);
-	quat_vecRot(&y, q);
-	quat_vecRot(&z, q);
+	quat_vecRot(&x, &q);
+	quat_vecRot(&y, &q);
+	quat_vecRot(&z, &q);
 
-	printf("%.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f\n", x.x, x.y, x.z, y.x, y.y, y.z, z.x, z.y, z.z, start->x, start->y, start->z);
+	printf("%.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f\n", x.x, x.y, x.z, y.x, y.y, y.z, z.x, z.y, z.z, start.x, start.y, start.z);
 }
 
 
 static void printUavAtt(ekf_state_t *uavState)
 {
-	printf("YPR: %f %f %f YPR_DOT %f %f %f\n", uavState->yaw,  uavState->pitch,  uavState->roll, uavState->yaw_dot,  uavState->pitch_dot,  uavState->roll_dot);
+	printf("YPR: %f %f %f YPR_DOT %f %f %f\n", uavState->yaw * 180 / 3.1415, uavState->pitch * 180 / 3.1415, uavState->roll * 180 / 3.1415, uavState->yaw_dot, uavState->pitch_dot, uavState->roll_dot);
+}
+
+
+static void printUavAcc(ekf_state_t *uavState)
+{
+	printf("XYZ %f %f %f\n", uavState->accelX, uavState->accelY, uavState->accelZ);
 }
 
 
 int main(int argc, char **argv)
 {
 	ekf_state_t uavState;
-
-	vec_t start = { 0 };
-	int i = 0;
 	enum printMode mode = prntVersor;
 
 	if (argc > 1) {
 		if (atoi(argv[1]) == 1) {
 			mode = prntAtt;
+		}
+		if (atoi(argv[1]) == 2) {
+			mode = printAcc;
 		}
 	}
 
@@ -63,7 +69,8 @@ int main(int argc, char **argv)
 		ekf_run();
 	}
 
-	while (i < 1000) {
+	/* This is testing app that may be used to present EKF capabilities and stability, thus no run time is set */
+	while (1) {
 		usleep(1000 * 100);
 		ekf_stateGet(&uavState);
 		if (mode == prntVersor) {
@@ -72,7 +79,9 @@ int main(int argc, char **argv)
 		if (mode == prntAtt) {
 			printUavAtt(&uavState);
 		}
-		i++;
+		if (mode == printAcc) {
+			printUavAcc(&uavState);
+		}
 	}
 
 	ekf_done();

--- a/ekf/tests/sensortest.c
+++ b/ekf/tests/sensortest.c
@@ -1,0 +1,125 @@
+/*
+ * Phoenix-Pilot
+ *
+ * extended kalman filter
+ * 
+ * ekf sensor reading test that aims to measure noise levels in sensor readings
+ *
+ * Copyright 2022 Phoenix Systems
+ * Author: Mateusz Niewiadomski
+ *
+ * This file is part of Phoenix-Pilot software
+ *
+ * %LICENSE%
+ */
+
+#include <board_config.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <sys/threads.h>
+
+#include "../sensc.h"
+#include <ekflib.h>
+
+#define R2D           57.2957
+#define POWER_HIGHEST 50
+#define POWER_LOWEST  10
+
+struct
+{
+	int m[4];
+	volatile int run;
+	char stack[2048];
+} sensortest_common;
+
+
+static void sensortest_helpPrint(const char *appName)
+{
+	printf("Usage: %s [throttle]\n", appName);
+	printf("  throttle - integer in range [%d,%d], interpreted as percents\n", POWER_LOWEST, POWER_HIGHEST);
+}
+
+
+static void sensortest_writeToAll(const char *val, int sz)
+{
+	int i = 0;
+	for (i = 0; i < 4; i++) {
+		write(sensortest_common.m[i], val, sz);
+	}
+}
+
+static void sensortest_thread(void *arg)
+{
+	sensor_event_t aEvt, gEvt, mEvt;
+	ekf_state_t uavState;
+
+	if (ekf_init() == 0) {
+		ekf_run();
+	}
+
+
+	while (sensortest_common.run > 0) {
+		usleep(1000 * 10);
+		sensc_imuGet(&aEvt, &gEvt, &mEvt);
+		ekf_stateGet(&uavState);
+		printf("%f %f %f %d %d %d %d %d %d %f %f %f\n", uavState.accelX, uavState.accelY, uavState.accelZ, gEvt.gyro.gyroX, gEvt.gyro.gyroY, gEvt.gyro.gyroZ, mEvt.mag.magX, mEvt.mag.magY, mEvt.mag.magZ, uavState.yaw * R2D, uavState.pitch * R2D, uavState.roll * R2D);
+	}
+
+	endthread();
+}
+
+
+int main(int argc, char **argv)
+{
+	unsigned int power, i;
+	char zero[] = "100000";
+	char goal[7];
+
+	if (argc <= 1) {
+		sensortest_helpPrint(argv[0]);
+		return -1;
+	}
+
+	power = atoi(argv[1]);
+	if (power > POWER_HIGHEST) {
+		printf("Throtle of %u too big! Max throttle = %d%%", power, POWER_HIGHEST);
+		return -1;
+	}
+	if (power < POWER_LOWEST) {
+		printf("Throtle of %d too low, Min throttle = %d%%\n", power, POWER_LOWEST);
+		return -1;
+	}
+
+	sensc_init("/dev/sensors");
+
+	sprintf(goal, "1%d000", power);
+
+	printf("WARNING: starting motors on %d%%!\n", power);
+	printf("Remove props or ensure safety of the test run! Press [Enter] to continue...\n");
+	getchar();
+
+	sensortest_common.m[0] = open(PWM_MOTOR1, O_WRONLY);
+	sensortest_common.m[1] = open(PWM_MOTOR2, O_WRONLY);
+	sensortest_common.m[2] = open(PWM_MOTOR3, O_WRONLY);
+	sensortest_common.m[3] = open(PWM_MOTOR4, O_WRONLY);
+
+	beginthread(sensortest_thread, 4, sensortest_common.stack, sizeof(sensortest_common.stack), NULL);
+
+	sensortest_writeToAll(zero, sizeof(zero));
+	sleep(9);
+	sensortest_writeToAll(goal, sizeof(goal));
+	sleep(7);
+	sensortest_writeToAll(zero, sizeof(zero));
+
+	sensortest_common.run = 0;
+	threadJoin(0);
+
+
+	for (i = 0; i < 4; i++) {
+		close(sensortest_common.m[i]);
+	}
+
+	return 0;
+}

--- a/ekf/tests/sensortest.c
+++ b/ekf/tests/sensortest.c
@@ -24,102 +24,190 @@
 #include <ekflib.h>
 
 #define R2D           57.2957
-#define POWER_HIGHEST 50
-#define POWER_LOWEST  10
+#define THROTTLE_MAX  50
+#define THROTTLE_MIN  10
+#define NUM_OF_MOTORS 4
 
-struct
-{
-	int m[4];
+struct {
+	int motorFile[NUM_OF_MOTORS];
 	volatile int run;
-	char stack[2048];
+	char stack[2048] __attribute__((aligned(8)));
+	char throttle[7];
 } sensortest_common;
 
 
 static void sensortest_helpPrint(const char *appName)
 {
 	printf("Usage: %s [throttle]\n", appName);
-	printf("  throttle - integer in range [%d,%d], interpreted as percents\n", POWER_LOWEST, POWER_HIGHEST);
+	printf("  throttle - integer in range [%d,%d], interpreted as percents\n", THROTTLE_MIN, THROTTLE_MAX);
 }
 
 
-static void sensortest_writeToAll(const char *val, int sz)
+static int sensortest_motorsWrite(const char *val, int sz)
 {
-	int i = 0;
-	for (i = 0; i < 4; i++) {
-		write(sensortest_common.m[i], val, sz);
+	int i;
+
+	for (i = 0; i < NUM_OF_MOTORS; i++) {
+		if (write(sensortest_common.motorFile[i], val, sz) != sz) {
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+static void sensortest_motorsClose(void)
+{
+	int i;
+
+	for (i = 0; i < NUM_OF_MOTORS; i++) {
+		if (sensortest_common.motorFile[i] >= 0) {
+			close(sensortest_common.motorFile[i]);
+		}
 	}
 }
 
 static void sensortest_thread(void *arg)
 {
-	sensor_event_t aEvt, gEvt, mEvt;
+	sensor_event_t accelEvt, gyroEvt, magEvt;
 	ekf_state_t uavState;
 
-	if (ekf_init() == 0) {
-		ekf_run();
-	}
-
-
+	sensortest_common.run = 1;
 	while (sensortest_common.run > 0) {
 		usleep(1000 * 10);
-		sensc_imuGet(&aEvt, &gEvt, &mEvt);
+		sensc_imuGet(&accelEvt, &gyroEvt, &magEvt);
 		ekf_stateGet(&uavState);
-		printf("%f %f %f %d %d %d %d %d %d %f %f %f\n", uavState.accelX, uavState.accelY, uavState.accelZ, gEvt.gyro.gyroX, gEvt.gyro.gyroY, gEvt.gyro.gyroZ, mEvt.mag.magX, mEvt.mag.magY, mEvt.mag.magZ, uavState.yaw * R2D, uavState.pitch * R2D, uavState.roll * R2D);
+		printf("%f %f %f %d %d %d %d %d %d %f %f %f\n", uavState.accelX, uavState.accelY, uavState.accelZ, gyroEvt.gyro.gyroX, gyroEvt.gyro.gyroY, gyroEvt.gyro.gyroZ, magEvt.mag.magX, magEvt.mag.magY, magEvt.mag.magZ, uavState.yaw * R2D, uavState.pitch * R2D, uavState.roll * R2D);
 	}
 
 	endthread();
 }
 
 
-int main(int argc, char **argv)
+static void sensortest_emergencyShutdown(const char *shutdownMsg, int msgSz)
 {
-	unsigned int power, i;
-	char zero[] = "100000";
-	char goal[7];
+	unsigned int motorShdwn[NUM_OF_MOTORS] = { 0 };
+	int i = 0, flag = 0;
 
-	if (argc <= 1) {
-		sensortest_helpPrint(argv[0]);
+	while (flag == 0) {
+		flag = 1;
+		for (i = 0; i < NUM_OF_MOTORS; i++) {
+			if ((motorShdwn[i] == 0) && (write(sensortest_common.motorFile[i], shutdownMsg, msgSz) != msgSz)) {
+				flag = 0;
+				printf("Emergency shutdown failed, retry...\n");
+			}
+			else {
+				motorShdwn[i] = 1;
+			}
+		}
+	}
+}
+
+
+static int sensortest_motorsProcedure(void)
+{
+	const char pwmInit[] = "100000";
+
+	if (sensortest_motorsWrite(pwmInit, sizeof(pwmInit)) < 0) {
+		sensortest_emergencyShutdown(pwmInit, sizeof(pwmInit));
 		return -1;
 	}
 
-	power = atoi(argv[1]);
-	if (power > POWER_HIGHEST) {
-		printf("Throtle of %u too big! Max throttle = %d%%", power, POWER_HIGHEST);
-		return -1;
-	}
-	if (power < POWER_LOWEST) {
-		printf("Throtle of %d too low, Min throttle = %d%%\n", power, POWER_LOWEST);
+	sleep(3);
+
+	if (sensortest_motorsWrite(sensortest_common.throttle, sizeof(sensortest_common.throttle)) < 0) {
+		sensortest_emergencyShutdown(pwmInit, sizeof(pwmInit));
 		return -1;
 	}
 
-	sensc_init("/dev/sensors");
-
-	sprintf(goal, "1%d000", power);
-
-	printf("WARNING: starting motors on %d%%!\n", power);
-	printf("Remove props or ensure safety of the test run! Press [Enter] to continue...\n");
-	getchar();
-
-	sensortest_common.m[0] = open(PWM_MOTOR1, O_WRONLY);
-	sensortest_common.m[1] = open(PWM_MOTOR2, O_WRONLY);
-	sensortest_common.m[2] = open(PWM_MOTOR3, O_WRONLY);
-	sensortest_common.m[3] = open(PWM_MOTOR4, O_WRONLY);
-
-	beginthread(sensortest_thread, 4, sensortest_common.stack, sizeof(sensortest_common.stack), NULL);
-
-	sensortest_writeToAll(zero, sizeof(zero));
-	sleep(9);
-	sensortest_writeToAll(goal, sizeof(goal));
 	sleep(7);
-	sensortest_writeToAll(zero, sizeof(zero));
 
-	sensortest_common.run = 0;
-	threadJoin(0);
-
-
-	for (i = 0; i < 4; i++) {
-		close(sensortest_common.m[i]);
+	if (sensortest_motorsWrite(pwmInit, sizeof(pwmInit)) < 0) {
+		sensortest_emergencyShutdown(pwmInit, sizeof(pwmInit));
+		return -1;
 	}
 
 	return 0;
+}
+
+
+int main(int argc, char **argv)
+{
+	unsigned int throttle, i, flag = 0;
+	int ret;
+
+	if (argc != 2) {
+		sensortest_helpPrint(argv[0]);
+		return EXIT_FAILURE;
+	}
+
+	throttle = atoi(argv[1]);
+	if (throttle > THROTTLE_MAX) {
+		printf("Throtle of %u too big! Max throttle = %d%%", throttle, THROTTLE_MAX);
+		return EXIT_FAILURE;
+	}
+	if (throttle < THROTTLE_MIN) {
+		printf("Throtle of %u too low, Min throttle = %d%%\n", throttle, THROTTLE_MIN);
+		return EXIT_FAILURE;
+	}
+
+	if (sensc_init("/dev/sensors") < 0) {
+		printf("cannot initialize sensor client\n");
+		return EXIT_FAILURE;
+	}
+
+	if (snprintf(sensortest_common.throttle, sizeof(sensortest_common.throttle), "1%d000", throttle) < 0) {
+		printf("cannot create correct throttle input\n");
+		return EXIT_FAILURE;
+	}
+
+	printf("WARNING: starting motors on %d%%!\n", throttle);
+	printf("Remove props or ensure safety of the test run! Press [Enter] to continue...\n");
+	getchar();
+
+	sensortest_common.motorFile[0] = open(PWM_MOTOR1, O_WRONLY);
+	sensortest_common.motorFile[1] = open(PWM_MOTOR2, O_WRONLY);
+	sensortest_common.motorFile[2] = open(PWM_MOTOR3, O_WRONLY);
+	sensortest_common.motorFile[3] = open(PWM_MOTOR4, O_WRONLY);
+
+	for (i = 0; i < NUM_OF_MOTORS; i++) {
+		if (sensortest_common.motorFile[i] < 0) {
+			printf("failed at opening %u-th motor descriptor\n", i);
+			flag = 1;
+		}
+	}
+	if (flag != 0) {
+		sensortest_motorsClose();
+		return EXIT_FAILURE;
+	}
+
+	if (ekf_init() != 0) {
+		printf("Cannot initialize ekf\n");
+		sensortest_motorsClose();
+		return EXIT_FAILURE;
+	}
+
+	if (ekf_run() < 0) {
+		printf("Cannot start ekf\n");
+		sensortest_motorsClose();
+		return EXIT_FAILURE;
+	}
+
+	if (beginthread(sensortest_thread, 4, sensortest_common.stack, sizeof(sensortest_common.stack), NULL) >= 0) {
+		/* data acquisition */
+		ret = sensortest_motorsProcedure();
+
+		sensortest_common.run = 0;
+		threadJoin(0);
+	}
+	else {
+		printf("Failed to start data acquisition thread\n");
+		ret = -1;
+	}
+
+	ekf_done();
+
+	sensortest_motorsClose();
+
+	return (ret == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/quadcontrol/control.c
+++ b/quadcontrol/control.c
@@ -64,7 +64,7 @@ enum { pwm_alt = 0, pwm_roll, pwm_pitch, pwm_yaw, pwm_max };
 static const flight_mode_t scenario[] = {
 	{ .type = flight_takeoff, .takeoff = { .alt = 2000 } },
 	{ .type = flight_hover, .hover = { .alt = 2000, .time = 10000 } },
-	{ .type = flight_landing },
+	/*{ .type = flight_landing }, TODO: activate when yaw measurement is enabled */
 	{ .type = flight_end },
 };
 #else
@@ -146,7 +146,7 @@ static int quad_takeoff(const flight_mode_t *mode)
 	DEBUG_LOG("TAKEOFF - alt: %d\n", mode->hover.alt);
 
 	/* Soft motors start */
-	for (throttle = 0.0; throttle < quad_common.throttle.max; throttle += 0.02f) {
+	for (throttle = 0.0; throttle < quad_common.throttle.max; throttle += 0.01f) {
 		if (quad_motorsCtrl(throttle, mode->hover.alt, 0, 0, 0) < 0) {
 			return -1;
 		}

--- a/quadcontrol/control.c
+++ b/quadcontrol/control.c
@@ -113,7 +113,8 @@ static int quad_motorsCtrl(float throttle, int32_t alt, int32_t roll, int32_t pi
 	}
 
 	now = quad_timeMsGet();
-	DEBUG_LOG("EKF: %lld, %f, %f, %f, %f\n", now, measure.yaw * RAD2DEG, measure.roll * RAD2DEG, measure.pitch * RAD2DEG, measure.enuZ);
+	DEBUG_LOG("EKFQ: %lld, %f, %f, %f, %f\n", now, measure.q0, measure.q1, measure.q2, measure.q3);
+	DEBUG_LOG("EKFE: %lld, %f, %f, %f\n", now, measure.yaw * RAD2DEG, measure.pitch * RAD2DEG, measure.roll * RAD2DEG);
 
 	dt = now - quad_common.lastTime;
 	quad_common.lastTime = now;
@@ -124,10 +125,10 @@ static int quad_motorsCtrl(float throttle, int32_t alt, int32_t roll, int32_t pi
 #endif
 
 	DEBUG_LOG("PID: %lld, ", now);
-	palt = pid_calc(&quad_common.pids[pwm_alt], alt, measure.enuZ * 1000, dt);
-	proll = pid_calc(&quad_common.pids[pwm_roll], roll, measure.roll, dt);
-	ppitch = pid_calc(&quad_common.pids[pwm_pitch], pitch, measure.pitch, dt);
-	pyaw = pid_calc(&quad_common.pids[pwm_yaw], yaw, measure.yaw, dt);
+	palt = pid_calc(&quad_common.pids[pwm_alt], alt, measure.enuZ * 1000, 0, dt);
+	proll = pid_calc(&quad_common.pids[pwm_roll], roll, measure.roll, measure.rollDot, dt);
+	ppitch = pid_calc(&quad_common.pids[pwm_pitch], pitch, measure.pitch, measure.pitchDot, dt);
+	pyaw = pid_calc(&quad_common.pids[pwm_yaw], yaw, measure.yaw, measure.yawDot, dt);
 	DEBUG_LOG("\n");
 
 	mma_control(throttle + palt, proll, ppitch, pyaw);

--- a/quadcontrol/pid.c
+++ b/quadcontrol/pid.c
@@ -19,7 +19,7 @@
 #include <stdio.h>
 
 
-float pid_calc(pid_ctx_t *pid, float setVal, float currVal, time_t dt)
+float pid_calc(pid_ctx_t *pid, float setVal, float currVal, float currValDot, time_t dt)
 {
 	float err, out;
 	float p, i, d; /* Results for proportional, integral and derivative parts of PID */
@@ -35,7 +35,7 @@ float pid_calc(pid_ctx_t *pid, float setVal, float currVal, time_t dt)
 	err = setVal - currVal;
 
 	/* Derivative */
-	d = (pid->kd * (err - pid->prevErr)) / dt;
+	d = pid->kd * currValDot;
 
 	/* Proportional */
 	p = pid->kp * err;
@@ -64,7 +64,7 @@ float pid_calc(pid_ctx_t *pid, float setVal, float currVal, time_t dt)
 	pid->prevErr = err;
 	pid->lastPid = out;
 
-	DEBUG_LOG("%f, %f, %f, ", p, i, d);
+	DEBUG_LOG("%f, %f, %f, %f, ", p, i, d, out);
 
 	return out;
 }

--- a/quadcontrol/pid.h
+++ b/quadcontrol/pid.h
@@ -38,8 +38,8 @@ typedef struct {
 extern int pid_init(pid_ctx_t *pid);
 
 
-/* Calculate the PID value based on gain values */
-extern float pid_calc(pid_ctx_t *pid, float setVal, float currVal, time_t dt);
+/* Calculate the PID value based on gain values and precalculated change rate */
+extern float pid_calc(pid_ctx_t *pid, float setVal, float currVal, float currValDot, time_t dt);
 
 
 /* TODO: Tuning gain coefficients */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Multiple commits, all but the first ([devekf: add selection to print versors or attitude](https://github.com/phoenix-pilot/phoenix-pilot-core/commit/dd538f86337b874e910987409eff4a1bdf628bc2)) were clang-format-ed before pushing.

Changes regarding minimizing accelerometer measurement noise impact on attitude estimation. Main changes were:
 - add acceleration logging possibilities to test applications
 - use ekf filtered accelerations in attitude estimation instead of basing attitude estimation on raw accelerometer measurements
 - heavily increased accelerometer noise factor in ekf R matrix
 - change in quadcontrol pid calculations so that they do not use error rate derrivative, but angular rates from ekf
 - small naming fixes

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
High levels of noise were found in signals on which attitude estimation is based on. Noise in such levels (stdev of noise > 4000 mm/s^2) was not encountered before as no props were mounted to the craft.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: zturn.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
