### PR TITLE
quadcontrol: revert to use `vfork()` and signal handling changes

### DIFF
--- a/quadcontrol/mma.c
+++ b/quadcontrol/mma.c
@@ -137,6 +137,7 @@ void mma_done(void)
 	/* make sure that motors are stopped before closing dev files */
 	mma_common.armed = 0;
 	_mma_motorsIdle();
+	usleep(100 * 1000);
 
 	for (i = 0; i < NUMBER_MOTORS; ++i) {
 		if (mma_common.files[i] != NULL) {


### PR DESCRIPTION
JIRA: PD-50

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Moved quadrocopter initialization to child process. Fixes problem where after fork ekf_getState() was not reading the newest data.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: zturn drone.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
