### PR TITLE
quad-control: add target attitude and enable yaw pid calculations

### DIFF
--- a/quadcontrol/control.c
+++ b/quadcontrol/control.c
@@ -46,7 +46,7 @@
 
 struct {
 	pid_ctx_t pids[PID_NUMBERS];
-	target_attitude_t targetAtt;
+	quad_att_t targetAtt;
 
 	time_t lastTime;
 #if TEST_ATTITUDE
@@ -446,7 +446,7 @@ static int quad_configRead(void)
 		if ((line[0] == '@') && (strcmp(&line[1], "PID\n") == 0)) {
 			err = quad_pidParse(file, pidCnt++);
 			if (err < 0) {
-				printf("pids\n");
+				fprintf(stderr, "quad-control: cannot parse pid parameters\n");
 				break;
 			}
 		}
@@ -455,7 +455,7 @@ static int quad_configRead(void)
 		if ((line[0] == '@') && (strcmp(&line[1], "THROTTLE\n") == 0)) {
 			err = quad_throttleParse(file);
 			if (err < 0) {
-				printf("throttle\n");
+				fprintf(stderr, "quad-control: cannot parse throttle parameters\n");
 				break;
 			}
 		}
@@ -464,6 +464,7 @@ static int quad_configRead(void)
 		if ((line[0] == '@') && (strcmp(&line[1], "ATTITUDE\n") == 0)) {
 			err = quad_attParse(file);
 			if (err < 0) {
+				fprintf(stderr, "quad-control: cannot parse attitude parameters\n");
 				break;
 			}
 		}

--- a/quadcontrol/control.h
+++ b/quadcontrol/control.h
@@ -31,9 +31,9 @@ typedef struct {
 
 
 typedef struct {
-	int32_t yaw;   /* yaw angle in milliradians in range (-PI, PI] */
-	int32_t pitch; /* pitch angle in milliradians in range (-PI/2, PI/2] */
-	int32_t roll;  /* roll angle in milliradians in range (-PI/2, PI/2] */
+	float yaw;   /* yaw angle in milliradians in range (-PI, PI] */
+	float pitch; /* pitch angle in milliradians in range (-PI/2, PI/2] */
+	float roll;  /* roll angle in milliradians in range (-PI/2, PI/2] */
 } target_attitude_t;
 
 

--- a/quadcontrol/control.h
+++ b/quadcontrol/control.h
@@ -34,7 +34,7 @@ typedef struct {
 	float yaw;   /* yaw angle in milliradians in range (-PI, PI] */
 	float pitch; /* pitch angle in milliradians in range (-PI/2, PI/2] */
 	float roll;  /* roll angle in milliradians in range (-PI/2, PI/2] */
-} target_attitude_t;
+} quad_att_t;
 
 
 typedef struct {

--- a/quadcontrol/control.h
+++ b/quadcontrol/control.h
@@ -31,6 +31,13 @@ typedef struct {
 
 
 typedef struct {
+	int32_t yaw;   /* yaw angle in milliradians in range (-PI, PI] */
+	int32_t pitch; /* pitch angle in milliradians in range (-PI/2, PI/2] */
+	int32_t roll;  /* roll angle in milliradians in range (-PI/2, PI/2] */
+} target_attitude_t;
+
+
+typedef struct {
 	int32_t alt; /* altitude in 1E-3 [m] (millimetres) above MSL */
 	int32_t lat; /* latitude in 1E-7 degrees */
 	int32_t lon; /* longitude in 1E-7 degrees */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
 - add target attitude parsing from `etc/quad.conf`
 - add target attitude usage in pid calculations

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: zturn drone

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
