### PR TITLE
quad-control: accounting for angles boundary values in pid calculations

### DIFF
--- a/ekf/ekflib.c
+++ b/ekf/ekflib.c
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 #include <time.h>
 #include <unistd.h>
+#include <math.h>
 #include <errno.h>
 #include <sys/time.h>
 #include <sys/threads.h>
@@ -130,6 +131,14 @@ void ekf_done(void)
 	threadJoin(0);
 	kmn_predDeinit(&ekf_common.stateEngine);
 	resourceDestroy(ekf_common.lock);
+}
+
+
+void ekf_boundsGet(float *bYaw, float *bRoll, float *bPitch)
+{
+	*bYaw = M_PI;
+	*bRoll = M_PI;
+	*bPitch = M_PI_2;
 }
 
 

--- a/ekf/include/ekflib.h
+++ b/ekf/include/ekflib.h
@@ -50,4 +50,6 @@ extern void ekf_done(void);
 
 extern void ekf_stateGet(ekf_state_t *ekf_state);
 
+extern void ekf_boundsGet(float *bYaw, float *bRoll, float *bPitch);
+
 #endif

--- a/quadcontrol/control.c
+++ b/quadcontrol/control.c
@@ -49,6 +49,7 @@ struct {
 	pid_ctx_t pids[PID_NUMBERS];
 
 	time_t lastTime;
+	quad_bounds_t bounds;
 #if TEST_ATTITUDE
 	quad_att_t targetAtt;
 	time_t duration;
@@ -527,6 +528,9 @@ static int quad_init(void)
 
 	/* EKF needs time to calibrate itself */
 	sleep(10);
+
+	/* get boundary values of euler angles from ekf module */
+	ekf_boundsGet(&(quad_common.bounds.boundYaw), &(quad_common.bounds.boundRoll), &(quad_common.bounds.boundPitch));
 
 	return 0;
 }

--- a/quadcontrol/control.c
+++ b/quadcontrol/control.c
@@ -136,10 +136,10 @@ static int quad_motorsCtrl(float throttle, int32_t alt, int32_t roll, int32_t pi
 	DEBUG_LOG("EKFE: %lld, %f, %f, %f\n", now, measure.yaw * RAD2DEG, measure.pitch * RAD2DEG, measure.roll * RAD2DEG);
 
 	DEBUG_LOG("PID: %lld, ", now);
-	palt = pid_calc(&quad_common.pids[pwm_alt], alt, measure.enuZ * 1000, 0, dt);
-	proll = pid_calc(&quad_common.pids[pwm_roll], roll / 1000.f, measure.roll, measure.rollDot, dt);
-	ppitch = pid_calc(&quad_common.pids[pwm_pitch], pitch / 1000.f, measure.pitch, measure.pitchDot, dt);
-	pyaw = pid_calc(&quad_common.pids[pwm_yaw], yaw / 1000.f, measure.yaw, measure.yawDot, dt);
+	palt = pid_calc(&quad_common.pids[pwm_alt], alt, measure.enuZ * 1000, 0, NO_BOUNDVAL, dt);
+	proll = pid_calc(&quad_common.pids[pwm_roll], roll / 1000.f, measure.roll, measure.rollDot, quad_common.bounds.boundRoll, dt);
+	ppitch = pid_calc(&quad_common.pids[pwm_pitch], pitch / 1000.f, measure.pitch, measure.pitchDot, quad_common.bounds.boundPitch, dt);
+	pyaw = pid_calc(&quad_common.pids[pwm_yaw], yaw / 1000.f, measure.yaw, measure.yawDot, quad_common.bounds.boundYaw, dt);
 	DEBUG_LOG("\n");
 
 	if (mma_control(throttle + palt, proll, ppitch, pyaw) < 0) {

--- a/quadcontrol/control.h
+++ b/quadcontrol/control.h
@@ -38,13 +38,6 @@ typedef struct {
 
 
 typedef struct {
-	float boundYaw;   /* boundary value for yaw angle */
-	float boundPitch; /* boundary value for pitch angle */
-	float boundRoll;  /* boundary value for roll angle */
-} quad_bounds_t;
-
-
-typedef struct {
 	int32_t alt; /* altitude in 1E-3 [m] (millimetres) above MSL */
 	int32_t lat; /* latitude in 1E-7 degrees */
 	int32_t lon; /* longitude in 1E-7 degrees */

--- a/quadcontrol/control.h
+++ b/quadcontrol/control.h
@@ -38,6 +38,13 @@ typedef struct {
 
 
 typedef struct {
+	float boundYaw;   /* boundary value for yaw angle */
+	float boundPitch; /* boundary value for pitch angle */
+	float boundRoll;  /* boundary value for roll angle */
+} quad_bounds_t;
+
+
+typedef struct {
 	int32_t alt; /* altitude in 1E-3 [m] (millimetres) above MSL */
 	int32_t lat; /* latitude in 1E-7 degrees */
 	int32_t lon; /* longitude in 1E-7 degrees */

--- a/quadcontrol/pid.c
+++ b/quadcontrol/pid.c
@@ -19,7 +19,7 @@
 #include <stdio.h>
 
 
-float pid_calc(pid_ctx_t *pid, float setVal, float currVal, float currValDot, time_t dt)
+float pid_calc(pid_ctx_t *pid, float setVal, float currVal, float currValDot, float boundVal, time_t dt)
 {
 	float err, out;
 	float p, i, d; /* Results for proportional, integral and derivative parts of PID */
@@ -33,6 +33,14 @@ float pid_calc(pid_ctx_t *pid, float setVal, float currVal, float currValDot, ti
 	}
 
 	err = setVal - currVal;
+
+	/* account for boundary values */
+	if (err > boundVal) {
+		err -= 2 * boundVal;
+	}
+	if (err < -boundVal) {
+		err += 2 * boundVal;
+	}
 
 	/* Derivative */
 	d = pid->kd * currValDot;

--- a/quadcontrol/pid.c
+++ b/quadcontrol/pid.c
@@ -19,7 +19,7 @@
 #include <stdio.h>
 
 
-float pid_calc(pid_ctx_t *pid, float setVal, float currVal, float currValDot, float boundVal, time_t dt)
+float pid_calc(pid_ctx_t *pid, float setVal, float currVal, float currValDot, time_t dt)
 {
 	float err, out;
 	float p, i, d; /* Results for proportional, integral and derivative parts of PID */
@@ -35,11 +35,13 @@ float pid_calc(pid_ctx_t *pid, float setVal, float currVal, float currValDot, fl
 	err = setVal - currVal;
 
 	/* account for boundary values */
-	if (err > boundVal) {
-		err -= 2 * boundVal;
-	}
-	if (err < -boundVal) {
-		err += 2 * boundVal;
+	if (pid->errBound != NO_BOUNDVAL) {
+		if (err > pid->errBound) {
+			err -= 2 * pid->errBound;
+		}
+		if (err < -pid->errBound) {
+			err += 2 * pid->errBound;
+		}
 	}
 
 	/* Derivative */
@@ -98,6 +100,8 @@ int pid_init(pid_ctx_t *pid)
 	pid->integral = 0;
 	pid->lastPid = 0;
 	pid->prevErr = 0;
+
+	pid->errBound = NO_BOUNDVAL;
 
 	return 0;
 }

--- a/quadcontrol/pid.h
+++ b/quadcontrol/pid.h
@@ -34,7 +34,7 @@ typedef struct {
 	float prevErr;  /* Previous error */
 	float lastPid;  /* Last calculated PID value */
 
-	float boundVal; /* positive boundary value for process variable (symmetric boundary value assumed) */
+	float errBound; /* positive boundary value for process variable (symmetric boundary value assumed) */
 } pid_ctx_t;
 
 
@@ -43,7 +43,7 @@ extern int pid_init(pid_ctx_t *pid);
 
 
 /* Calculate the PID value based on gain values and precalculated change rate */
-extern float pid_calc(pid_ctx_t *pid, float setVal, float currVal, float currValDot, float boundVal, time_t dt);
+extern float pid_calc(pid_ctx_t *pid, float setVal, float currVal, float currValDot, time_t dt);
 
 
 /* TODO: Tuning gain coefficients */

--- a/quadcontrol/pid.h
+++ b/quadcontrol/pid.h
@@ -16,6 +16,8 @@
 
 #include <time.h>
 
+#define NO_BOUNDVAL 0.0
+
 typedef struct {
 	/* Coefficients */
 	float kp; /* proportional gain */
@@ -31,6 +33,8 @@ typedef struct {
 	float integral; /* Accumulate for integral term */
 	float prevErr;  /* Previous error */
 	float lastPid;  /* Last calculated PID value */
+
+	float boundVal; /* positive boundary value for process variable (symmetric boundary value assumed) */
 } pid_ctx_t;
 
 
@@ -39,7 +43,7 @@ extern int pid_init(pid_ctx_t *pid);
 
 
 /* Calculate the PID value based on gain values and precalculated change rate */
-extern float pid_calc(pid_ctx_t *pid, float setVal, float currVal, float currValDot, time_t dt);
+extern float pid_calc(pid_ctx_t *pid, float setVal, float currVal, float currValDot, float boundVal, time_t dt);
 
 
 /* TODO: Tuning gain coefficients */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Currently no boundary values check is performed on values that go to pid. Proposed solution:
 - adds boundary values specification in ekflib
 - adds reading those ekflib bounds in quad-control:control.c
 - accounts for boundary values in pid calculation process

Symmetric boundary values are assumed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: zturn drone

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
