### PR TITLE
algebra/matrix: fix `matrix_bufAlloc()` arguments unsignedness

### DIFF
--- a/algebra/include/matrix.h
+++ b/algebra/include/matrix.h
@@ -25,7 +25,7 @@ typedef struct {
 extern void matrix_zeroes(matrix_t *A);
 
 
-extern int matrix_bufAlloc(matrix_t *matrix, int rows, int cols);
+extern int matrix_bufAlloc(matrix_t *matrix, unsigned int rows, unsigned int cols);
 
 
 extern void matrix_bufFree(matrix_t *matrix);

--- a/algebra/matrix.c
+++ b/algebra/matrix.c
@@ -14,6 +14,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 
 #include "matrix.h"
 
@@ -21,9 +22,14 @@ float * buf = NULL;
 unsigned int buflen = 0;
 
 
-int matrix_bufAlloc(matrix_t *matrix, int rows, int cols)
+int matrix_bufAlloc(matrix_t *matrix, unsigned int rows, unsigned int cols)
 {
 	float *data;
+
+	/* check for calloc 'nitems' overflow */
+	if (SIZE_MAX / rows < cols) {
+		return -1;
+	}
 
 	data = calloc(rows * cols, sizeof(float));
 	if (data == NULL) {


### PR DESCRIPTION
JIRA: PP-71

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Bugfix - the `matrix_t` structure elements are `unsigned int` but values passed to `matrix_bufAlloc()` are signed. This causes casting errors and overall mess.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
