### PR TITLE
algebra: change all `inline` functions in `matrix.h` to `static inline`

### DIFF
--- a/algebra/include/matrix.h
+++ b/algebra/include/matrix.h
@@ -35,19 +35,19 @@ extern void matrix_bufFree(matrix_t *matrix);
 
 /* return a pointer to matrix element in specified row and column
  * if row or column exceeds matrix size NULL is returned */
-inline float *matrix_at(const matrix_t *A, unsigned int row, unsigned int col)
+static inline float *matrix_at(const matrix_t *A, unsigned int row, unsigned int col)
 {
 	return (A->transposed) ? ((row < A->cols && col < A->rows) ? &(A->data[A->cols * col + row]) : NULL) : ((row < A->rows && col < A->cols) ? &(A->data[A->cols * row + col]) : NULL);
 }
 
 
-inline unsigned int matrix_rowsGet(matrix_t *A)
+static inline unsigned int matrix_rowsGet(matrix_t *A)
 {
 	return (A->transposed) ? A->cols : A->rows;
 }
 
 
-inline unsigned int matrix_colsGet(matrix_t *A)
+static inline unsigned int matrix_colsGet(matrix_t *A)
 {
 	return (A->transposed) ? A->rows : A->cols;
 }


### PR DESCRIPTION
JIRA: PP-89

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Some inline functions in `libalgeb` header files were declared not `static`. `static` keyword was added.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
