### PR TITLE
calibtool: switch to `libcalib` library

### DIFF
--- a/calib/Makefile
+++ b/calib/Makefile
@@ -10,5 +10,5 @@
 NAME := calibtool
 CALIBS := magmot.c magiron.c
 LOCAL_SRCS := main.c hmap.c $(CALIBS)
-DEP_LIBS := libsensc libmctl libalgeb
+DEP_LIBS := libsensc libmctl libalgeb libcalib
 include $(binary.mk)

--- a/calib/calibtool.h
+++ b/calib/calibtool.h
@@ -34,7 +34,7 @@ typedef struct {
 	const char *(*help)(void);             /* help message description */
 	int (*write)(FILE *);                  /* calibration file data write */
 
-	calib_data_t *(*calStructGet)(void); /* returns internal structure of libcalib:calib_data_t type */
+	calib_data_t *(*dataGet)(void); /* returns internal structure of libcalib:calib_data_t type */
 } calib_ops_t;
 
 

--- a/calib/calibtool.h
+++ b/calib/calibtool.h
@@ -32,7 +32,6 @@ typedef struct _calib_t {
 
 	/* utility related */
 	const char *(*help)(void);             /* help message description */
-	int (*interpret)(const char *, float); /* calibration file data interpreter */
 	int (*write)(FILE *);                  /* calibration file data write */
 
 	calib_t *(*calStructGet)(void); /* returns internal structure of libcalib:calib_t type */

--- a/calib/calibtool.h
+++ b/calib/calibtool.h
@@ -17,6 +17,8 @@
 #include <stdbool.h>
 #include <stdio.h>
 
+#include <calib.h>
+
 
 #define SENSOR_PATH "/dev/sensors"
 
@@ -32,10 +34,12 @@ typedef struct _calib_t {
 	const char *(*help)(void);             /* help message description */
 	int (*interpret)(const char *, float); /* calibration file data interpreter */
 	int (*write)(FILE *);                  /* calibration file data write */
-} calib_t;
+
+	calib_t *(*calStructGet)(void); /* returns internal structure of libcalib:calib_t type */
+} calibration_t;
 
 
 /* registering new calibration procedure */
-void calib_register(calib_t *c);
+void calib_register(calibration_t *c);
 
 #endif

--- a/calib/calibtool.h
+++ b/calib/calibtool.h
@@ -34,7 +34,7 @@ typedef struct {
 	const char *(*help)(void);             /* help message description */
 	int (*write)(FILE *);                  /* calibration file data write */
 
-	calib_t *(*calStructGet)(void); /* returns internal structure of libcalib:calib_t type */
+	calib_data_t *(*calStructGet)(void); /* returns internal structure of libcalib:calib_data_t type */
 } calib_ops_t;
 
 

--- a/calib/calibtool.h
+++ b/calib/calibtool.h
@@ -22,7 +22,7 @@
 
 #define SENSOR_PATH "/dev/sensors"
 
-typedef struct _calib_t {
+typedef struct {
 	char name[16]; /* alias of this calibration */
 
 	/* process related */
@@ -35,10 +35,10 @@ typedef struct _calib_t {
 	int (*write)(FILE *);                  /* calibration file data write */
 
 	calib_t *(*calStructGet)(void); /* returns internal structure of libcalib:calib_t type */
-} calibration_t;
+} calib_ops_t;
 
 
 /* registering new calibration procedure */
-void calib_register(calibration_t *c);
+void calib_register(calib_ops_t *c);
 
 #endif

--- a/calib/magiron.c
+++ b/calib/magiron.c
@@ -24,21 +24,7 @@
 #include "calibtool.h"
 
 
-#define SOFTCAL_ROWSPAN 3
-#define SOFTCAL_COLSPAN 3
-#define HARDCAL_ROWSPAN 3
-#define HARDCAL_COLSPAN 1
-
-
 struct {
-	/* Calibration parameters */
-	matrix_t softCal;
-	matrix_t hardCal;
-
-	/* Utility variables */
-	float softCalBuf[SOFTCAL_ROWSPAN * SOFTCAL_COLSPAN];
-	float hardCalBuf[HARDCAL_ROWSPAN * HARDCAL_COLSPAN];
-
 	calib_t params;
 } magiron_common;
 

--- a/calib/magiron.c
+++ b/calib/magiron.c
@@ -20,7 +20,7 @@
 #include <matrix.h>
 #include <vec.h>
 
-#include "calib.h"
+#include "calibtool.h"
 
 
 #define CHAR_HARDIRON 'h'
@@ -191,7 +191,7 @@ static void cal_magironPreinit(void)
 
 __attribute__((constructor(102))) static void cal_magironRegister(void)
 {
-	static calib_t cal = {
+	static calibration_t cal = {
 		.name = "magiron",
 		.init = cal_magironInit,
 		.run = cal_magironRun,

--- a/calib/magiron.c
+++ b/calib/magiron.c
@@ -25,15 +25,15 @@
 
 
 struct {
-	calib_data_t params;
+	calib_data_t data;
 } magiron_common;
 
 
 /* Returns pointer to internal parameters for read purposes */
 static calib_data_t *magiron_calibStructGet(void)
 {
-	magiron_common.params.type = typeMagiron;
-	return &magiron_common.params;
+	magiron_common.data.type = typeMagiron;
+	return &magiron_common.data;
 }
 
 
@@ -56,10 +56,10 @@ static void magiron_printIron(FILE *file, char type, matrix_t *mat)
 static int cal_magironWrite(FILE *file)
 {
 	/* Printing hard iron calibration parameters */
-	magiron_printIron(file, CHAR_HARDIRON, &magiron_common.params.params.magiron.hardCal);
+	magiron_printIron(file, CHAR_HARDIRON, &magiron_common.data.params.magiron.hardCal);
 
 	/* Printing soft iron calibration parameters */
-	magiron_printIron(file, CHAR_SOFTIRON, &magiron_common.params.params.magiron.softCal);
+	magiron_printIron(file, CHAR_SOFTIRON, &magiron_common.data.params.magiron.softCal);
 
 	return 0;
 }

--- a/calib/magiron.c
+++ b/calib/magiron.c
@@ -97,7 +97,7 @@ static int cal_magironInit(int argc, const char **argv)
 
 __attribute__((constructor(102))) static void cal_magironRegister(void)
 {
-	static calibration_t cal = {
+	static calib_ops_t cal = {
 		.name = MAGIRON_TAG,
 		.init = cal_magironInit,
 		.run = cal_magironRun,

--- a/calib/magiron.c
+++ b/calib/magiron.c
@@ -25,12 +25,12 @@
 
 
 struct {
-	calib_t params;
+	calib_data_t params;
 } magiron_common;
 
 
 /* Returns pointer to internal parameters for read purposes */
-static calib_t *magiron_calibStructGet(void)
+static calib_data_t *magiron_calibStructGet(void)
 {
 	magiron_common.params.type = typeMagiron;
 	return &magiron_common.params;

--- a/calib/magiron.c
+++ b/calib/magiron.c
@@ -24,9 +24,6 @@
 #include "calibtool.h"
 
 
-#define CHAR_HARDIRON 'h'
-#define CHAR_SOFTIRON 's'
-
 #define SOFTCAL_ROWSPAN 3
 #define SOFTCAL_COLSPAN 3
 #define HARDCAL_ROWSPAN 3
@@ -51,40 +48,6 @@ static calib_t *magiron_calibStructGet(void)
 {
 	magiron_common.params.type = typeMagiron;
 	return &magiron_common.params;
-}
-
-
-/* returns pointer do data slot named as 'paramName' */
-static float *magiron_paramSlot(const char *paramName)
-{
-	matrix_t *mat;
-	unsigned int row, col;
-
-	if (strlen(paramName) != 3) {
-		return NULL;
-	}
-
-	/* variable casting for MISRA compliance */
-	row = (uint8_t)(paramName[1] - '0'); /* convert character to unsigned int digit */
-	col = (uint8_t)(paramName[2] - '0'); /* convert character to unsigned int digit */
-	if (row > (unsigned int)'9' || col > (unsigned int)'9') {
-		return NULL;
-	}
-
-	/* matrix type get through character check */
-	switch (paramName[0]) {
-		case CHAR_SOFTIRON:
-			mat = &magiron_common.softCal;
-			break;
-		case CHAR_HARDIRON:
-			mat = &magiron_common.softCal;
-			break;
-		default:
-			return NULL;
-	}
-
-	/* matrix boundary checks performed by matrix_at() */
-	return matrix_at(mat, row, col);
 }
 
 
@@ -113,21 +76,6 @@ static int cal_magironWrite(FILE *file)
 	magiron_printIron(file, CHAR_SOFTIRON, &magiron_common.params.params.magiron.softCal);
 
 	return 0;
-}
-
-
-static int cal_magironInterpret(const char *name, float val)
-{
-	float *valSlot;
-
-	valSlot = magiron_paramSlot(name);
-	if (valSlot == NULL) {
-		return -ENOENT;
-	}
-
-	*valSlot = val;
-
-	return EOK;
 }
 
 
@@ -161,59 +109,17 @@ static int cal_magironInit(int argc, const char **argv)
 }
 
 
-static void cal_magironPreinit(void)
-{
-	/* Soft iron calibration matrix init */
-	magiron_common.softCal.cols = SOFTCAL_COLSPAN;
-	magiron_common.softCal.rows = SOFTCAL_ROWSPAN;
-	magiron_common.softCal.transposed = 0;
-	magiron_common.softCal.data = magiron_common.softCalBuf;
-	matrix_diag(&magiron_common.softCal);
-
-	/* hard iron calibration matrix init */
-	magiron_common.hardCal.cols = HARDCAL_COLSPAN;
-	magiron_common.hardCal.rows = HARDCAL_ROWSPAN;
-	magiron_common.hardCal.transposed = 0;
-	magiron_common.hardCal.data = magiron_common.hardCalBuf;
-	matrix_zeroes(&magiron_common.hardCal);
-
-	/*
-	* FIXME: Precalibrated data injection.
-	* This must be removed when full procedure is implemented
-	*/
-
-	/* hard iron vector matrix */
-	*matrix_at(&magiron_common.hardCal, 0, 0) = 42.47503636;
-	*matrix_at(&magiron_common.hardCal, 1, 0) = 1084.20661751;
-	*matrix_at(&magiron_common.hardCal, 2, 0) = -111.58247011;
-
-	/* soft iron matrix */
-	*matrix_at(&magiron_common.softCal, 0, 0) = 0.9409439;
-	*matrix_at(&magiron_common.softCal, 0, 1) = 0.09766692;
-	*matrix_at(&magiron_common.softCal, 0, 2) = -0.01307758;
-	*matrix_at(&magiron_common.softCal, 1, 0) = 0.09766692;
-	*matrix_at(&magiron_common.softCal, 1, 1) = 1.01364504;
-	*matrix_at(&magiron_common.softCal, 1, 2) = -0.01144832;
-	*matrix_at(&magiron_common.softCal, 2, 0) = -0.01307758;
-	*matrix_at(&magiron_common.softCal, 2, 1) = -0.01144832;
-	*matrix_at(&magiron_common.softCal, 2, 2) = 1.0593312;
-}
-
-
 __attribute__((constructor(102))) static void cal_magironRegister(void)
 {
 	static calibration_t cal = {
-		.name = "magiron",
+		.name = MAGIRON_TAG,
 		.init = cal_magironInit,
 		.run = cal_magironRun,
 		.done = cal_magironDone,
-		.interpret = cal_magironInterpret,
 		.write = cal_magironWrite,
 		.help = cal_magironHelp,
 		.calStructGet = magiron_calibStructGet
 	};
 
 	calib_register(&cal);
-
-	cal_magironPreinit();
 }

--- a/calib/magiron.c
+++ b/calib/magiron.c
@@ -104,7 +104,7 @@ __attribute__((constructor(102))) static void cal_magironRegister(void)
 		.done = cal_magironDone,
 		.write = cal_magironWrite,
 		.help = cal_magironHelp,
-		.calStructGet = magiron_calibStructGet
+		.dataGet = magiron_calibStructGet
 	};
 
 	calib_register(&cal);

--- a/calib/magiron.c
+++ b/calib/magiron.c
@@ -30,9 +30,8 @@ struct {
 
 
 /* Returns pointer to internal parameters for read purposes */
-static calib_data_t *magiron_calibStructGet(void)
+static calib_data_t *magiron_dataGet(void)
 {
-	magiron_common.data.type = typeMagiron;
 	return &magiron_common.data;
 }
 
@@ -53,7 +52,7 @@ static void magiron_printIron(FILE *file, char type, matrix_t *mat)
 }
 
 
-static int cal_magironWrite(FILE *file)
+static int magiron_write(FILE *file)
 {
 	/* Printing hard iron calibration parameters */
 	magiron_printIron(file, CHAR_HARDIRON, &magiron_common.data.params.magiron.hardCal);
@@ -65,20 +64,20 @@ static int cal_magironWrite(FILE *file)
 }
 
 
-static const char *cal_magironHelp(void)
+static const char *magiron_help(void)
 {
 	return "Magnetometer calibration against soft/hard iron interference.\n";
 }
 
 
-static int cal_magironDone(void)
+static int magiron_done(void)
 {
 	/* Stub implementation. Calibration procedure returns precompiled data */
 	return EOK;
 }
 
 
-static int cal_magironRun(void)
+static int magiron_run(void)
 {
 	printf("This calibration procedure is not implemented and it returns precalculated values!\n Press enter to continue...\n");
 	getchar();
@@ -88,24 +87,26 @@ static int cal_magironRun(void)
 }
 
 
-static int cal_magironInit(int argc, const char **argv)
+static int magiron_init(int argc, const char **argv)
 {
 	/* Stub implementation. Calibration procedure returns precompiled data */
 	return EOK;
 }
 
 
-__attribute__((constructor(102))) static void cal_magironRegister(void)
+__attribute__((constructor(102))) static void magiron_register(void)
 {
 	static calib_ops_t cal = {
 		.name = MAGIRON_TAG,
-		.init = cal_magironInit,
-		.run = cal_magironRun,
-		.done = cal_magironDone,
-		.write = cal_magironWrite,
-		.help = cal_magironHelp,
-		.dataGet = magiron_calibStructGet
+		.init = magiron_init,
+		.run = magiron_run,
+		.done = magiron_done,
+		.write = magiron_write,
+		.help = magiron_help,
+		.dataGet = magiron_dataGet
 	};
 
 	calib_register(&cal);
+
+	magiron_common.data.type = typeMagiron;
 }

--- a/calib/magiron.c
+++ b/calib/magiron.c
@@ -107,10 +107,10 @@ static void magiron_printIron(FILE *file, char type, matrix_t *mat)
 static int cal_magironWrite(FILE *file)
 {
 	/* Printing hard iron calibration parameters */
-	magiron_printIron(file, CHAR_HARDIRON, &magiron_common.hardCal);
+	magiron_printIron(file, CHAR_HARDIRON, &magiron_common.params.params.magiron.hardCal);
 
 	/* Printing soft iron calibration parameters */
-	magiron_printIron(file, CHAR_SOFTIRON, &magiron_common.softCal);
+	magiron_printIron(file, CHAR_SOFTIRON, &magiron_common.params.params.magiron.softCal);
 
 	return 0;
 }

--- a/calib/magiron.c
+++ b/calib/magiron.c
@@ -19,6 +19,7 @@
 
 #include <matrix.h>
 #include <vec.h>
+#include <calib.h>
 
 #include "calibtool.h"
 
@@ -40,7 +41,17 @@ struct {
 	/* Utility variables */
 	float softCalBuf[SOFTCAL_ROWSPAN * SOFTCAL_COLSPAN];
 	float hardCalBuf[HARDCAL_ROWSPAN * HARDCAL_COLSPAN];
+
+	calib_t params;
 } magiron_common;
+
+
+/* Returns pointer to internal parameters for read purposes */
+static calib_t *magiron_calibStructGet(void)
+{
+	magiron_common.params.type = typeMagiron;
+	return &magiron_common.params;
+}
 
 
 /* returns pointer do data slot named as 'paramName' */
@@ -198,7 +209,8 @@ __attribute__((constructor(102))) static void cal_magironRegister(void)
 		.done = cal_magironDone,
 		.interpret = cal_magironInterpret,
 		.write = cal_magironWrite,
-		.help = cal_magironHelp
+		.help = cal_magironHelp,
+		.calStructGet = magiron_calibStructGet
 	};
 
 	calib_register(&cal);

--- a/calib/magmot.c
+++ b/calib/magmot.c
@@ -278,7 +278,7 @@ __attribute__((constructor(102))) static void cal_magmotRegister(void)
 		.done = cal_magmotDone,
 		.write = cal_magmotWrite,
 		.help = cal_magmotHelp,
-		.calStructGet = magmot_calibStructGet
+		.dataGet = magmot_calibStructGet
 	};
 
 	calib_register(&cal);

--- a/calib/magmot.c
+++ b/calib/magmot.c
@@ -26,7 +26,7 @@
 #include <vec.h>
 #include <matrix.h>
 
-#include "calib.h"
+#include "calibtool.h"
 
 
 #define AVG_SAMPLES  100
@@ -299,7 +299,7 @@ static int cal_magmotInit(int argc, const char **argv)
 __attribute__((constructor(102))) static void cal_magmotRegister(void)
 {
 	unsigned int motor, axis, param;
-	static calib_t cal = {
+	static calibration_t cal = {
 		.name = "magmot",
 		.init = cal_magmotInit,
 		.run = cal_magmotRun,

--- a/calib/magmot.c
+++ b/calib/magmot.c
@@ -196,7 +196,7 @@ static int cal_magmotWrite(FILE *file)
 		for (axis = 0; axis < 3; axis++) {
 			for (param = 0; param < 3; param++) {
 				magmot_paramName(motor, axis, param, paramName);
-				fprintf(file, "%s %f\n", paramName, magmot_common.motorEq[motor][axis][param]);
+				fprintf(file, "%s %f\n", paramName, magmot_common.params.params.magmot.motorEq[motor][axis][param]);
 			}
 		}
 	}

--- a/calib/magmot.c
+++ b/calib/magmot.c
@@ -271,7 +271,7 @@ static int cal_magmotInit(int argc, const char **argv)
 
 __attribute__((constructor(102))) static void cal_magmotRegister(void)
 {
-	static calibration_t cal = {
+	static calib_ops_t cal = {
 		.name = MAGMOT_TAG,
 		.init = cal_magmotInit,
 		.run = cal_magmotRun,

--- a/calib/magmot.c
+++ b/calib/magmot.c
@@ -45,15 +45,14 @@ static const char *motorFiles[] = {
 };
 
 struct {
-	calib_data_t params;
+	calib_data_t data;
 } magmot_common;
 
 
 /* Returns pointer to internal parameters for read purposes */
 static calib_data_t *magmot_calibStructGet(void)
 {
-	magmot_common.params.type = typeMagmot;
-	return &magmot_common.params;
+	return &magmot_common.data;
 }
 
 
@@ -171,7 +170,7 @@ static int cal_magmotWrite(FILE *file)
 		for (axis = 0; axis < 3; axis++) {
 			for (param = 0; param < 3; param++) {
 				magmot_paramName(motor, axis, param, paramName);
-				fprintf(file, "%s %f\n", paramName, magmot_common.params.params.magmot.motorEq[motor][axis][param]);
+				fprintf(file, "%s %f\n", paramName, magmot_common.data.params.magmot.motorEq[motor][axis][param]);
 			}
 		}
 	}
@@ -230,7 +229,7 @@ static int cal_magmotRun(void)
 		usleep(1000 * 400); /* wait for engine to slow down */
 
 		/* aliasing for better readability */
-		motorEq = magmot_common.params.params.magmot.motorEq;
+		motorEq = magmot_common.data.params.magmot.motorEq;
 
 		/* fitting quadratic equation for magnetometer x-axis interference from m-th engine */
 		magmot_qlsmFit(x, y[0], CALIB_POINTS, &motorEq[m][0][0], &motorEq[m][0][1], &motorEq[m][0][2]);
@@ -282,4 +281,6 @@ __attribute__((constructor(102))) static void cal_magmotRegister(void)
 	};
 
 	calib_register(&cal);
+
+	magmot_common.data.type = typeMagmot;
 }

--- a/calib/magmot.c
+++ b/calib/magmot.c
@@ -45,9 +45,6 @@ static const char *motorFiles[] = {
 };
 
 struct {
-	/* motorEq[motorId 0/1/2...NUM_OF_MOTORS][axisId x/y/z][equation_param a/b/c] */
-	float motorEq[NUM_OF_MOTORS][3][3];
-
 	calib_t params;
 } magmot_common;
 
@@ -194,6 +191,7 @@ static int cal_magmotRun(void)
 	float thrtl = 0, thrtlStep, startThrtl = 0.3;
 	float x[CALIB_POINTS], y[3][CALIB_POINTS];
 	unsigned int m, pts;
+	float (*motorEq)[3][3];
 
 	/* arm motors in safe mode. Warnings displayed by mctl_arm() */
 	if (mctl_arm(armMode_user) < 0) {
@@ -231,12 +229,15 @@ static int cal_magmotRun(void)
 		}
 		usleep(1000 * 400); /* wait for engine to slow down */
 
+		/* aliasing for better readability */
+		motorEq = magmot_common.params.params.magmot.motorEq;
+
 		/* fitting quadratic equation for magnetometer x-axis interference from m-th engine */
-		magmot_qlsmFit(x, y[0], CALIB_POINTS, &magmot_common.motorEq[m][0][0], &magmot_common.motorEq[m][0][1], &magmot_common.motorEq[m][0][2]);
+		magmot_qlsmFit(x, y[0], CALIB_POINTS, &motorEq[m][0][0], &motorEq[m][0][1], &motorEq[m][0][2]);
 		/* fitting quadratic equation for magnetometer y-axis interference from m-th engine */
-		magmot_qlsmFit(x, y[1], CALIB_POINTS, &magmot_common.motorEq[m][1][0], &magmot_common.motorEq[m][1][1], &magmot_common.motorEq[m][1][2]);
+		magmot_qlsmFit(x, y[1], CALIB_POINTS, &motorEq[m][1][0], &motorEq[m][1][1], &motorEq[m][1][2]);
 		/* fitting quadratic equation for magnetometer z-axis interference from m-th engine */
-		magmot_qlsmFit(x, y[2], CALIB_POINTS, &magmot_common.motorEq[m][2][0], &magmot_common.motorEq[m][2][1], &magmot_common.motorEq[m][2][2]);
+		magmot_qlsmFit(x, y[2], CALIB_POINTS, &motorEq[m][2][0], &motorEq[m][2][1], &motorEq[m][2][2]);
 	}
 	mctl_disarm();
 

--- a/calib/magmot.c
+++ b/calib/magmot.c
@@ -50,7 +50,7 @@ struct {
 
 
 /* Returns pointer to internal parameters for read purposes */
-static calib_data_t *magmot_calibStructGet(void)
+static calib_data_t *magmot_dataGet(void)
 {
 	return &magmot_common.data;
 }
@@ -161,7 +161,7 @@ static void magmot_paramName(unsigned int motorId, unsigned int axisId, unsigned
 }
 
 
-static int cal_magmotWrite(FILE *file)
+static int magmot_write(FILE *file)
 {
 	unsigned int motor, axis, param;
 	char paramName[5];
@@ -178,13 +178,13 @@ static int cal_magmotWrite(FILE *file)
 }
 
 
-const char *cal_magmotHelp(void)
+const char *magmot_help(void)
 {
 	return "Magnetometer vs engine interference calibration\n";
 }
 
 
-static int cal_magmotRun(void)
+static int magmot_run(void)
 {
 	vec_t magBase, magCurr, magDiff;
 	float thrtl = 0, thrtlStep, startThrtl = 0.3;
@@ -244,7 +244,7 @@ static int cal_magmotRun(void)
 }
 
 
-static int cal_magmotDone(void)
+static int magmot_done(void)
 {
 	sensc_deinit();
 	mctl_deinit();
@@ -253,7 +253,7 @@ static int cal_magmotDone(void)
 }
 
 
-static int cal_magmotInit(int argc, const char **argv)
+static int magmot_init(int argc, const char **argv)
 {
 	if (sensc_init(SENSOR_PATH) < 0) {
 		return -ENXIO;
@@ -268,16 +268,16 @@ static int cal_magmotInit(int argc, const char **argv)
 }
 
 
-__attribute__((constructor(102))) static void cal_magmotRegister(void)
+__attribute__((constructor(102))) static void magmot_register(void)
 {
 	static calib_ops_t cal = {
 		.name = MAGMOT_TAG,
-		.init = cal_magmotInit,
-		.run = cal_magmotRun,
-		.done = cal_magmotDone,
-		.write = cal_magmotWrite,
-		.help = cal_magmotHelp,
-		.dataGet = magmot_calibStructGet
+		.init = magmot_init,
+		.run = magmot_run,
+		.done = magmot_done,
+		.write = magmot_write,
+		.help = magmot_help,
+		.dataGet = magmot_dataGet
 	};
 
 	calib_register(&cal);

--- a/calib/magmot.c
+++ b/calib/magmot.c
@@ -25,6 +25,7 @@
 #include <mctl.h>
 #include <vec.h>
 #include <matrix.h>
+#include <calib.h>
 
 #include "calibtool.h"
 
@@ -46,7 +47,17 @@ static const char *motorFiles[] = {
 struct {
 	/* motorEq[motorId 0/1/2...NUM_OF_MOTORS][axisId x/y/z][equation_param a/b/c] */
 	float motorEq[NUM_OF_MOTORS][3][3];
+
+	calib_t params;
 } magmot_common;
+
+
+/* Returns pointer to internal parameters for read purposes */
+static calib_t *magmot_calibStructGet(void)
+{
+	magmot_common.params.type = typeMagmot;
+	return &magmot_common.params;
+}
 
 
 /*
@@ -306,7 +317,8 @@ __attribute__((constructor(102))) static void cal_magmotRegister(void)
 		.done = cal_magmotDone,
 		.interpret = cal_magmotInterpret,
 		.write = cal_magmotWrite,
-		.help = cal_magmotHelp
+		.help = cal_magmotHelp,
+		.calStructGet = magmot_calibStructGet
 	};
 
 	calib_register(&cal);

--- a/calib/magmot.c
+++ b/calib/magmot.c
@@ -45,12 +45,12 @@ static const char *motorFiles[] = {
 };
 
 struct {
-	calib_t params;
+	calib_data_t params;
 } magmot_common;
 
 
 /* Returns pointer to internal parameters for read purposes */
-static calib_t *magmot_calibStructGet(void)
+static calib_data_t *magmot_calibStructGet(void)
 {
 	magmot_common.params.type = typeMagmot;
 	return &magmot_common.params;

--- a/calib/main.c
+++ b/calib/main.c
@@ -17,7 +17,7 @@
 #include <stdbool.h>
 #include <errno.h>
 
-#include "calib.h"
+#include "calibtool.h"
 #include "hmap.h"
 
 #define CALIB_FILE  "/etc/calib.conf" /* Path to calibration parameters file */
@@ -33,8 +33,8 @@ struct {
 } calib_common;
 
 
-/* Register new calib_t procedure. */
-void calib_register(calib_t *c)
+/* Register new calibration_t procedure. */
+void calib_register(calibration_t *c)
 {
 	if (hmap_insert(calib_common.calibs, c->name, c) < 0) {
 		fprintf(stderr, "calibtool: ailed to register %s procedure\n", c->name);
@@ -45,7 +45,7 @@ void calib_register(calib_t *c)
 static void calib_help(void)
 {
 	unsigned int iter;
-	calib_t *cal;
+	calibration_t *cal;
 
 	printf("Usage: calibtool mode [ARGS]\n");
 	printf(
@@ -56,7 +56,7 @@ static void calib_help(void)
 
 	/* iterating over hashmap */
 	iter = 0;
-	cal = (calib_t *)hmap_next(calib_common.calibs, &iter);
+	cal = (calibration_t *)hmap_next(calib_common.calibs, &iter);
 	while (cal != NULL) {
 		if (cal->help == NULL) {
 			fprintf(stderr, "calibtool: calibration %s lacks help function\n", cal->name);
@@ -65,7 +65,7 @@ static void calib_help(void)
 			printf("  %s%s%s:\n  %s\n", COLOR_BOLD, cal->name, COLOR_OFF, cal->help());
 		}
 
-		cal = (calib_t *)hmap_next(calib_common.calibs, &iter);
+		cal = (calibration_t *)hmap_next(calib_common.calibs, &iter);
 	}
 }
 
@@ -77,7 +77,7 @@ static void calib_help(void)
 static int calib_read(const char *path)
 {
 	FILE *file;
-	calib_t *cal;
+	calibration_t *cal;
 	char *head, *val, *line = NULL;
 	size_t lineSz = 0;
 	unsigned int lineNum = 0;
@@ -159,7 +159,7 @@ static int calib_write(const char *path)
 	int ret = EOK;
 	unsigned int iter;
 	FILE *file;
-	calib_t *cal;
+	calibration_t *cal;
 
 	file = fopen(path, "w");
 	if (file == NULL) {
@@ -171,13 +171,13 @@ static int calib_write(const char *path)
 
 	/* iterating over hashmap */
 	iter = 0;
-	cal = (calib_t *)hmap_next(calib_common.calibs, &iter);
+	cal = (calibration_t *)hmap_next(calib_common.calibs, &iter);
 	while (cal != NULL) {
 		fprintf(file, "@%s\n", cal->name); /* print tag */
 		cal->write(file);                  /* call for data print */
 		fprintf(file, "\n\n");             /* print newlines for separation */
 
-		cal = (calib_t *)hmap_next(calib_common.calibs, &iter);
+		cal = (calibration_t *)hmap_next(calib_common.calibs, &iter);
 	}
 
 	if (file != stdout) {
@@ -189,7 +189,7 @@ static int calib_write(const char *path)
 
 
 /* calibration routine scheme */
-static int calib_do(calib_t *cal, int argc, const char **argv)
+static int calib_do(calibration_t *cal, int argc, const char **argv)
 {
 	int ret;
 
@@ -221,7 +221,7 @@ static int calib_do(calib_t *cal, int argc, const char **argv)
 
 int main(int argc, const char **argv)
 {
-	calib_t *cal;
+	calibration_t *cal;
 
 	if (argc <= 1) {
 		fprintf(stderr, "calibtool: wrong arguments.\n");

--- a/calib/main.c
+++ b/calib/main.c
@@ -77,7 +77,7 @@ static void calib_help(void)
 static int calib_read(const char *path)
 {
 	calib_ops_t *c;
-	calib_t *calib;
+	calib_data_t *calib;
 	unsigned int i = 0, inited = 0;
 	bool err = false;
 

--- a/calib/main.c
+++ b/calib/main.c
@@ -20,8 +20,8 @@
 #include "calibtool.h"
 #include "hmap.h"
 
-#define CALIB_FILE  "/etc/calib.conf" /* Path to calibration parameters file */
-#define CALIBS_SIZE 16                /* Maximum number of calibrations available. Can be freely increased */
+#define PATH_CALIB_FILE "/etc/calib.conf" /* Path to calibration parameters file */
+#define CALIBS_SIZE     16                /* Maximum number of calibrations available. Can be freely increased */
 
 /* text formatting defined */
 #define COLOR_BOLD "\e[1m"
@@ -201,7 +201,7 @@ int main(int argc, const char **argv)
 	}
 
 	/* Read calibration file */
-	if (calib_read(CALIB_FILE) != 0) {
+	if (calib_read(PATH_CALIB_FILE) != 0) {
 		fprintf(stderr, "calibtool: error on calibrations initialization\n");
 		return EXIT_FAILURE;
 	}
@@ -212,7 +212,7 @@ int main(int argc, const char **argv)
 	}
 
 	/* Write updated calibration parameters to file */
-	if (calib_write(CALIB_FILE) != EOK) {
+	if (calib_write(PATH_CALIB_FILE) != EOK) {
 		return EXIT_FAILURE;
 	}
 

--- a/calib/main.c
+++ b/calib/main.c
@@ -83,7 +83,7 @@ static int calib_read(const char *path)
 
 	c = (calib_ops_t *)hmap_next(calib_common.calibs, &i);
 	while (c != NULL) {
-		calib = c->calStructGet();
+		calib = c->dataGet();
 		if (calib_readFile(path, calib->type, calib) != 0) {
 			err = true;
 			break;
@@ -98,7 +98,7 @@ static int calib_read(const char *path)
 		i = 0;
 		while (inited > 0) {
 			c = (calib_ops_t *)hmap_next(calib_common.calibs, &i);
-			calib = c->calStructGet();
+			calib = c->dataGet();
 			calib_free(calib);
 			inited--;
 		}

--- a/calib/main.c
+++ b/calib/main.c
@@ -148,7 +148,7 @@ static int calib_write(const char *path)
 
 
 /* calibration routine scheme */
-static int calib_do(calib_ops_t *cal, int argc, const char **argv)
+static int calib_run(calib_ops_t *cal, int argc, const char **argv)
 {
 	int ret;
 
@@ -207,7 +207,7 @@ int main(int argc, const char **argv)
 	}
 
 	/* Perform calibration */
-	if (calib_do(cal, argc, argv) != EOK) {
+	if (calib_run(cal, argc, argv) != EOK) {
 		return EXIT_FAILURE;
 	}
 

--- a/libs/calib/calib.c
+++ b/libs/calib/calib.c
@@ -63,7 +63,7 @@ static int calib_getline(char **bufptr, size_t *bufSz, FILE *file, char **name, 
 
 
 /* Returns pointer to correct parameter variable given name `paramName` for magmot calibration */
-static float *calib_magmotSlot(const char *paramName, calib_t *cal)
+static float *calib_magmotSlot(const char *paramName, calib_data_t *cal)
 {
 	unsigned int motor, axis, param;
 
@@ -84,14 +84,14 @@ static float *calib_magmotSlot(const char *paramName, calib_t *cal)
 }
 
 
-static inline void calib_magmotDefaults(calib_t *cal)
+static inline void calib_magmotDefaults(calib_data_t *cal)
 {
 	/* set all parameters to 0 */
 	memset(cal->params.magmot.motorEq, 0, sizeof(cal->params.magmot.motorEq));
 }
 
 
-static int calib_magmotRead(FILE *file, calib_t *cal)
+static int calib_magmotRead(FILE *file, calib_data_t *cal)
 {
 	char *line, *name;
 	size_t lineSz;
@@ -127,7 +127,7 @@ static int calib_magmotRead(FILE *file, calib_t *cal)
 
 
 /* returns pointer do data slot named as 'paramName' */
-static float *magiron_paramSlot(const char *paramName, calib_t *cal)
+static float *magiron_paramSlot(const char *paramName, calib_data_t *cal)
 {
 	matrix_t *mat;
 	unsigned int row, col;
@@ -166,7 +166,7 @@ static float *magiron_paramSlot(const char *paramName, calib_t *cal)
 }
 
 
-static inline void calib_magironDefaults(calib_t *cal)
+static inline void calib_magironDefaults(calib_data_t *cal)
 {
 	/* Creating constant aliases of matrices */
 	const matrix_t hardCal = cal->params.magiron.hardCal;
@@ -190,7 +190,7 @@ static inline void calib_magironDefaults(calib_t *cal)
 }
 
 
-static int calib_magironRead(FILE *file, calib_t *cal)
+static int calib_magironRead(FILE *file, calib_data_t *cal)
 {
 	char *line, *name;
 	size_t lineSz;
@@ -238,7 +238,7 @@ static int calib_magironRead(FILE *file, calib_t *cal)
 }
 
 
-void calib_free(calib_t *cal)
+void calib_free(calib_data_t *cal)
 {
 	switch (cal->type) {
 		case typeMagiron:
@@ -253,7 +253,7 @@ void calib_free(calib_t *cal)
 }
 
 
-int calib_readFile(const char *path, calibType_t type, calib_t *cal)
+int calib_readFile(const char *path, calibType_t type, calib_data_t *cal)
 {
 	FILE *file;
 	int ret;

--- a/libs/calib/calib.c
+++ b/libs/calib/calib.c
@@ -119,7 +119,7 @@ static int calib_magmotRead(FILE *file, calib_data_t *cal)
 
 	if (params != MAGMOT_PARAMS) {
 		calib_magmotDefaults(cal);
-		return -1;
+		fprintf(stderr, "Failed to read `%s` calibration. Going default.\n", MAGIRON_TAG);
 	}
 
 	return 0;

--- a/libs/calib/calib.h
+++ b/libs/calib/calib.h
@@ -48,7 +48,10 @@ typedef struct {
 } calib_data_t;
 
 
-/* read calibration file pointed by 'path' searching for calibration named `tag` and saving its content to 'cal' */
+/*
+* Read calibration file pointed by 'path' searching for calibration named `tag` and saving its content to 'cal'.
+* If 'path' does not point to a file default values are written and 0 is returned (success).
+*/
 int calib_readFile(const char *path, calibType_t type, calib_data_t *cal);
 
 

--- a/libs/calib/calib.h
+++ b/libs/calib/calib.h
@@ -45,15 +45,15 @@ typedef struct {
 			float motorEq[NUM_OF_MOTORS][3][3]; /* motorEq[motorId 0/1/2...NUM_OF_MOTORS][axisId x/y/z][equation_param a/b/c] */
 		} magmot;
 	} params;
-} calib_t;
+} calib_data_t;
 
 
 /* read calibration file pointed by 'path' searching for calibration named `tag` and saving its content to 'cal' */
-int calib_readFile(const char *path, calibType_t type, calib_t *cal);
+int calib_readFile(const char *path, calibType_t type, calib_data_t *cal);
 
 
 /* Deallocates all memory used by 'cal' */
-void calib_free(calib_t *cal);
+void calib_free(calib_data_t *cal);
 
 
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Recent addition of `libcalib` makes a lot of `calibttol` redundant and unnecessary. Changes in this PR make `calibtool` dependent on `libcalib`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
