### PR TITLE
ekf: remove magnetometer calibration

### DIFF
--- a/ekf/measurement.c
+++ b/ekf/measurement.c
@@ -52,15 +52,6 @@ float acc_calib1[12] = {
 	-0.00315447, 0.00175213, 0.9965838
 };
 
-/* magnetometer calibration data */
-float mag_calib1[12] = {
-	/* sphere offset in 10^-7 T (milligauss)*/
-	42.47503636, 1084.20661751, -111.58247011,
-	/* sphere deformation */
-	0.9409439, 0.09766692, -0.01307758,
-	0.09766692, 1.01364504, -0.01144832,
-	-0.01307758, -0.01144832, 1.0593312
-};
 
 vec_t geo2ecef(float lat, float lon, float h)
 {
@@ -228,7 +219,6 @@ void meas_imuCalib(void)
 			meas_mag2si(&magEvt, &mag);
 
 			meas_ellipCompensate(&acc, acc_calib1);
-			meas_ellipCompensate(&mag, mag_calib1);
 
 			vec_add(&accAvg, &acc);
 			vec_add(&gyrAvg, &gyr);
@@ -295,7 +285,6 @@ int meas_imuGet(vec_t *accels, vec_t *gyros, vec_t *mags, uint64_t *timestamp)
 	meas_mag2si(&magEvt, mags);   /* only magnitude matters from geomagnetism */
 
 	meas_ellipCompensate(accels, acc_calib1);
-	meas_ellipCompensate(mags, mag_calib1);
 
 	/* gyro niveling */
 	vec_sub(gyros, &meas_common.calib.gyr_nivel);


### PR DESCRIPTION
 - no more needed after libcalib implementation

JIRA: PP-89

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
After magnetometer calibration is done in libsensc there is no nedd for another in ekf.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: zturn drone

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
