### PR TITLE
Adding tests for `quat_quat2euler` function

### DIFF
--- a/algebra/include/quat.h
+++ b/algebra/include/quat.h
@@ -91,8 +91,8 @@ extern void quat_sandwichFast(const quat_t *A, const quat_t *B, quat_t *C);
 extern void quat_times(quat_t *A, float x);
 
 
-/* calculates rotation euler angles from rotation quaternion */
-extern void quat_quat2euler(quat_t *q, float *roll, float *pitch, float *yaw);
+/* Calculates rotation euler angles from rotation quaternion. Hierarchy of angels are yaw, pitch, roll (ZYX) */
+extern void quat_quat2euler(const quat_t *q, float *roll, float *pitch, float *yaw);
 
 
 /* calculate quaternion q that rotates v1 into v2, assumed len(v1) == len(v2) */

--- a/algebra/quat.c
+++ b/algebra/quat.c
@@ -65,7 +65,7 @@ void quat_mlt(const quat_t *A, const quat_t *B, quat_t *C)
 
 float quat_dot(const quat_t *A, const quat_t *B)
 {
-	return A->a * B->a + A->i * B->i + A->j * B->j + A->k * B->k; 
+	return A->a * B->a + A->i * B->i + A->j * B->j + A->k * B->k;
 }
 
 
@@ -74,7 +74,7 @@ void quat_cjg(quat_t *A)
 	A->i = -A->i;
 	A->j = -A->j;
 	A->k = -A->k;
-	//return (quat_t){.a = A->a, .i = -A->i, .j = -A->j, .k = -A->k};
+	// return (quat_t){.a = A->a, .i = -A->i, .j = -A->j, .k = -A->k};
 }
 
 
@@ -128,13 +128,15 @@ void quat_times(quat_t *A, float x)
 }
 
 
-void quat_quat2euler(quat_t *q, float *roll, float *pitch, float *yaw)
+void quat_quat2euler(const quat_t *q, float *roll, float *pitch, float *yaw)
 {
+	quat_t tmp = *q;
+
 	/* FIXME: is this normalization needed? */
-	quat_normalize(q);
-	*roll = atan2(2 * (q->a * q->i + q->j * q->k), 1 - 2 * (q->i * q->i + q->j * q->j));
-	*pitch = asin(2 * (q->a * q->j - q->k * q->i));
-	*yaw = atan2(2 * (q->a * q->k + q->i * q->j), 1 - 2 * (q->j * q->j + q->k * q->k));
+	quat_normalize(&tmp);
+	*roll = atan2(2 * (tmp.a * tmp.i + tmp.j * tmp.k), 1 - 2 * (tmp.i * tmp.i + tmp.j * tmp.j));
+	*pitch = asin(2 * (tmp.a * tmp.j - tmp.k * tmp.i));
+	*yaw = atan2(2 * (tmp.a * tmp.k + tmp.i * tmp.j), 1 - 2 * (tmp.j * tmp.j + tmp.k * tmp.k));
 }
 
 
@@ -169,10 +171,10 @@ void quat_uvec2uvec(const vec_t *v1, const vec_t *v2, quat_t *q)
 
 void quat_vecRot(vec_t *vec, const quat_t *qRot)
 {
-	quat_t * v; 
+	quat_t *v;
 
 	/* cast vector as quaternion */
-	v = (quat_t*)vec;
+	v = (quat_t *)vec;
 	v->a = 0;
 
 	quat_sandwichFast(qRot, v, v);

--- a/algebra/tests/main.c
+++ b/algebra/tests/main.c
@@ -61,6 +61,7 @@ void runner(void)
 	RUN_TEST_GROUP(group_quat_dot);
 	RUN_TEST_GROUP(group_quat_sandwich);
 	RUN_TEST_GROUP(group_quat_normalize);
+	RUN_TEST_GROUP(group_quat_quat2euler);
 }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
This PR changes behavior of `quat_quat2euler` function. Now function does not change passed quaternion. Moreover it has tests for `quat_quat2euler` function.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Better interface for interaction with quaternions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [x] New test added: (add PR link here). In this PR
- [x] Tested by hand on: (list targets here). `armv7a9-zynq7000-qemu`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
