### PR TITLE
algebra: adding tests for self subtraction in `matrix_sub` function

### DIFF
--- a/algebra/tests/matrix/addition_and_subtraction.c
+++ b/algebra/tests/matrix/addition_and_subtraction.c
@@ -725,6 +725,52 @@ TEST(group_matrix_sub_stdMat, matrix_sub_allMatTrp)
 }
 
 
+TEST(group_matrix_sub_stdMat, matrix_sub_selfSubStd)
+{
+	TEST_ASSERT_EQUAL_INT(SUB_OK, matrix_sub(&M1, &M2, NULL));
+
+	TEST_ASSERT_EQUAL_MATRIX(Exp, M1);
+}
+
+
+TEST(group_matrix_sub_stdMat, matrix_sub_selfSubFirstMatTrp)
+{
+	/* Matrix is changed in such way that logically it is the same but .transposed is true */
+	TEST_ASSERT_EQUAL_INT(BUF_ALLOC_OK, algebraTests_transposeSwap(&M1));
+
+	/* Result matrix have transposition flag equal to first matrix */
+	TEST_ASSERT_EQUAL_INT(BUF_ALLOC_OK, algebraTests_transposeSwap(&Exp));
+
+	TEST_ASSERT_EQUAL_INT(SUB_OK, matrix_sub(&M1, &M2, NULL));
+
+	TEST_ASSERT_EQUAL_MATRIX(Exp, M1);
+}
+
+
+TEST(group_matrix_sub_stdMat, matrix_sub_selfSubSecondMatTrp)
+{
+	TEST_ASSERT_EQUAL_INT(BUF_ALLOC_OK, algebraTests_transposeSwap(&M2));
+
+	TEST_ASSERT_EQUAL_INT(SUB_OK, matrix_sub(&M1, &M2, NULL));
+
+	TEST_ASSERT_EQUAL_MATRIX(Exp, M1);
+}
+
+
+TEST(group_matrix_sub_stdMat, matrix_sub_selfSubAllMatTrp)
+{
+	TEST_ASSERT_EQUAL_INT(BUF_ALLOC_OK, algebraTests_transposeSwap(&M1));
+	TEST_ASSERT_EQUAL_INT(BUF_ALLOC_OK, algebraTests_transposeSwap(&M2));
+
+	/* Result matrix have transposition flag equal to first matrix */
+	TEST_ASSERT_EQUAL_INT(BUF_ALLOC_OK, algebraTests_transposeSwap(&Exp));
+
+	TEST_ASSERT_EQUAL_INT(SUB_OK, matrix_sub(&M1, &M2, NULL));
+
+	TEST_ASSERT_EQUAL_MATRIX(Exp, M1);
+}
+
+
 TEST_GROUP(group_matrix_sub_bigMat);
 
 
@@ -864,6 +910,62 @@ TEST(group_matrix_sub_bigMat, matrix_sub_bigMatsAllMatTrp)
 }
 
 
+TEST(group_matrix_sub_bigMat, matrix_sub_selfSubBigMatsStd)
+{
+	TEST_ASSERT_EQUAL_INT(SUB_OK, matrix_sub(&M1, &M2, NULL));
+
+	TEST_ASSERT_EQUAL_MATRIX(Exp, M1);
+}
+
+
+TEST(group_matrix_sub_bigMat, matrix_sub_selfSubBigMatsFirstMatTrp)
+{
+	TEST_ASSERT_EQUAL_INT(BUF_ALLOC_OK, algebraTests_transposeSwap(&M1));
+
+	/* Result matrix have transposition flag equal to first matrix */
+	TEST_ASSERT_EQUAL_INT(BUF_ALLOC_OK, algebraTests_transposeSwap(&Exp));
+
+	TEST_ASSERT_EQUAL_INT(SUB_OK, matrix_sub(&M1, &M2, NULL));
+
+	TEST_ASSERT_EQUAL_MATRIX(Exp, M1);
+}
+
+
+TEST(group_matrix_sub_bigMat, matrix_sub_selfSubBigMatsSecondMatTrp)
+{
+	TEST_ASSERT_EQUAL_INT(BUF_ALLOC_OK, algebraTests_transposeSwap(&M2));
+
+	TEST_ASSERT_EQUAL_INT(SUB_OK, matrix_sub(&M1, &M2, NULL));
+
+	TEST_ASSERT_EQUAL_MATRIX(Exp, M1);
+}
+
+
+TEST(group_matrix_sub_bigMat, matrix_sub_selfSubBigAllMatTrp)
+{
+	TEST_ASSERT_EQUAL_INT(BUF_ALLOC_OK, algebraTests_transposeSwap(&M1));
+	TEST_ASSERT_EQUAL_INT(BUF_ALLOC_OK, algebraTests_transposeSwap(&M2));
+
+	/* Result matrix have transposition flag equal to first matrix */
+	TEST_ASSERT_EQUAL_INT(BUF_ALLOC_OK, algebraTests_transposeSwap(&Exp));
+
+	TEST_ASSERT_EQUAL_INT(SUB_OK, matrix_sub(&M1, &M2, NULL));
+
+	TEST_ASSERT_EQUAL_MATRIX(Exp, M1);
+}
+
+
+/* This tests checks if function changes source matrices after success */
+TEST(group_matrix_sub_bigMat, matrix_sub_selfSubSourceRetain)
+{
+	TEST_ASSERT_EQUAL_INT(BUF_ALLOC_OK, algebraTests_matrixCopy(&M4, &M2));
+
+	TEST_ASSERT_EQUAL_INT(SUB_OK, matrix_sub(&M1, &M2, NULL));
+
+	TEST_ASSERT_EQUAL_MATRIX(M4, M2);
+}
+
+
 /* This tests checks if function changes source matrices after success */
 TEST(group_matrix_sub_bigMat, matrix_sub_sourceRetain)
 {
@@ -962,6 +1064,46 @@ TEST(group_matrix_sub_badMats, matrix_sub_failureRetain)
 }
 
 
+TEST(group_matrix_add_badMats, matrix_add_selfSubBadInputMats)
+{
+	M2.rows--;
+	M2.cols--;
+
+	/* No matrix is transposed */
+	TEST_ASSERT_EQUAL_INT(SUB_FAIL, matrix_sub(&M1, &M2, NULL));
+
+	/* First matrix is transposed */
+	matrix_trp(&M1);
+
+	TEST_ASSERT_EQUAL_INT(SUB_FAIL, matrix_sub(&M1, &M2, NULL));
+
+	/* Second matrix is transposed */
+	matrix_trp(&M1);
+	matrix_trp(&M2);
+
+	TEST_ASSERT_EQUAL_INT(SUB_FAIL, matrix_sub(&M1, &M2, NULL));
+
+	/* First and second transposed */
+	matrix_trp(&M1);
+
+	TEST_ASSERT_EQUAL_INT(SUB_FAIL, matrix_sub(&M1, &M2, NULL));
+}
+
+
+/* This test checks if result matrix is changing when function fails */
+TEST(group_matrix_add_badMats, matrix_add_selfSubFailureRetain)
+{
+	M2.rows--;
+	M2.cols--;
+
+	TEST_ASSERT_EQUAL_INT(BUF_ALLOC_OK, algebraTests_matrixCopy(&M4, &M1));
+
+	TEST_ASSERT_EQUAL_INT(SUB_FAIL, matrix_sub(&M1, &M2, NULL));
+
+	TEST_ASSERT_EQUAL_MATRIX(M4, M1);
+}
+
+
 TEST_GROUP_RUNNER(group_matrix_sub)
 {
 	RUN_TEST_CASE(group_matrix_sub_stdMat, matrix_sub_std);
@@ -973,6 +1115,11 @@ TEST_GROUP_RUNNER(group_matrix_sub)
 	RUN_TEST_CASE(group_matrix_sub_stdMat, matrix_sub_resultAndSecondMatTrp);
 	RUN_TEST_CASE(group_matrix_sub_stdMat, matrix_sub_allMatTrp);
 
+	RUN_TEST_CASE(group_matrix_sub_stdMat, matrix_sub_selfSubStd);
+	RUN_TEST_CASE(group_matrix_sub_stdMat, matrix_sub_selfSubFirstMatTrp);
+	RUN_TEST_CASE(group_matrix_sub_stdMat, matrix_sub_selfSubSecondMatTrp);
+	RUN_TEST_CASE(group_matrix_sub_stdMat, matrix_sub_selfSubAllMatTrp);
+
 	RUN_TEST_CASE(group_matrix_sub_bigMat, matrix_sub_bigMatsStd);
 	RUN_TEST_CASE(group_matrix_sub_bigMat, matrix_sub_bigMatsFirstMatTrp);
 	RUN_TEST_CASE(group_matrix_sub_bigMat, matrix_sub_bigMatsSecondMatTrp);
@@ -982,9 +1129,17 @@ TEST_GROUP_RUNNER(group_matrix_sub)
 	RUN_TEST_CASE(group_matrix_sub_bigMat, matrix_sub_bigMatsResultAndSecondMatTrp);
 	RUN_TEST_CASE(group_matrix_sub_bigMat, matrix_sub_bigMatsAllMatTrp);
 
+	RUN_TEST_CASE(group_matrix_sub_bigMat, matrix_sub_selfSubBigMatsStd);
+	RUN_TEST_CASE(group_matrix_sub_bigMat, matrix_sub_selfSubBigMatsFirstMatTrp);
+	RUN_TEST_CASE(group_matrix_sub_bigMat, matrix_sub_selfSubBigMatsSecondMatTrp);
+	RUN_TEST_CASE(group_matrix_sub_bigMat, matrix_sub_selfSubBigAllMatTrp);
+
+	RUN_TEST_CASE(group_matrix_sub_bigMat, matrix_sub_selfSubSourceRetain);
 	RUN_TEST_CASE(group_matrix_sub_bigMat, matrix_sub_sourceRetain);
 
 	RUN_TEST_CASE(group_matrix_sub_badMats, matrix_sub_badInputMats);
 	RUN_TEST_CASE(group_matrix_sub_badMats, matrix_sub_badResMat);
 	RUN_TEST_CASE(group_matrix_sub_badMats, matrix_sub_failureRetain);
+	RUN_TEST_CASE(group_matrix_add_badMats, matrix_add_selfSubBadInputMats);
+	RUN_TEST_CASE(group_matrix_add_badMats, matrix_add_selfSubFailureRetain);
 }


### PR DESCRIPTION
JIRA: PP-71

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Checking `A -= B` behavior of `matrix_sub` function

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
More precise tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here). `armv7a9-zynq7000-qemu`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
