### PR TITLE
calib: corrections after integration tests

### DIFF
--- a/libs/calib/calib.c
+++ b/libs/calib/calib.c
@@ -117,6 +117,7 @@ static int calib_magmotRead(FILE *file, calib_data_t *cal)
 		if (valuePtr == NULL) {
 			break;
 		}
+		*valuePtr = value;
 		params++;
 	}
 	free(line);

--- a/libs/sensc/corr.c
+++ b/libs/sensc/corr.c
@@ -148,15 +148,13 @@ static int corr_magmotRecalc(vec_t *correction)
 		*  - x is throttle (scalar),
 		*  - a/b/c are parameters (vectors),
 		*  - y is impact of current motor on magnetometer reading (vector)
-		*
-		* Minuses in equation make it a correction, not an error. Correction should be added to measurement.
 		*/
 		vec_times(&axisImpact[0], throttle * throttle);
 		vec_times(&axisImpact[1], throttle);
 
-		vec_sub(&impact, &axisImpact[0]);
-		vec_sub(&impact, &axisImpact[1]);
-		vec_sub(&impact, &axisImpact[2]);
+		vec_add(&impact, &axisImpact[0]);
+		vec_add(&impact, &axisImpact[1]);
+		vec_add(&impact, &axisImpact[2]);
 	}
 
 	*correction = impact;

--- a/libs/sensc/corr.c
+++ b/libs/sensc/corr.c
@@ -118,6 +118,7 @@ static int corr_magmotRecalc(vec_t *correction)
 
 	/* Read current throttles from pwmFiles */
 	for (motor = 0; motor < NUM_OF_MOTORS; motor++) {
+		rewind(corr_common.pwmFiles[motor]);
 		fread(buff, sizeof(char), sizeof(buff), corr_common.pwmFiles[motor]);
 
 		throttles[motor] = strtod(buff, NULL);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
 - changes in pwm file read as it requires rewinding on each read
 - Missing assignment found in magmot correction resulting in not reading parameters.
 - Magmot correction sign was flipped resulting in overcompensation

This brunch is 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: zturn drone

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
