### PR TITLE
Fixing and adding tests for `quat_uvec2uvec` function

### DIFF
--- a/algebra/include/quat.h
+++ b/algebra/include/quat.h
@@ -95,7 +95,7 @@ extern void quat_times(quat_t *A, float x);
 extern void quat_quat2euler(const quat_t *q, float *roll, float *pitch, float *yaw);
 
 
-/* calculate quaternion q that rotates v1 into v2, assumed len(v1) == len(v2) */
+/* calculate quaternion q that rotates v1 into v2. `v1` and `v2` need to be unit vectors */
 extern void quat_uvec2uvec(const vec_t *v1, const vec_t *v2, quat_t *q);
 
 

--- a/algebra/quat.c
+++ b/algebra/quat.c
@@ -144,15 +144,18 @@ void quat_uvec2uvec(const vec_t *v1, const vec_t *v2, quat_t *q)
 {
 	float a = vec_dot(v1, v2);
 	quat_t qv1, qv2;
+	/*vec_t tmp;*/
 
-	if (a > 0.99999999) {
+	if (a > 0.999999f) {
 		/* if vectors are close to parallel */
 		quat_idenWrite(q);
 		return;
 	}
-	if (a < -0.99999999) {
+	if (a < -0.999999f) {
 		/* if vectors are close to antiparallel */
-		quat_piWrite(q);
+		/* calculating quaternion, which rotates 180 degrees along axis perpendicular to `v1` and `v2` */
+		vec_normal(v1, v2, (vec_t *)q);
+		q->a = 0;
 		return;
 	}
 

--- a/algebra/tests/main.c
+++ b/algebra/tests/main.c
@@ -67,6 +67,7 @@ void runner(void)
 	RUN_TEST_GROUP(group_quat_quat2euler);
 	RUN_TEST_GROUP(group_quat_vecRot);
 	RUN_TEST_GROUP(group_quat_rotQuat);
+	RUN_TEST_GROUP(group_quat_uvec2uvec);
 }
 
 

--- a/algebra/tests/quat/various.c
+++ b/algebra/tests/quat/various.c
@@ -103,6 +103,13 @@ static const float Angle = 1;
 /* Quaternion of rotation about `Angle` and along `V3` axis */
 static const quat_t Q9 = { .a = 0.8775826f, .i = 0.3888655f, .j = 0.155546f, .k = 0.2333193f };
 
+/* Vector nearly antiparallel to V3 */
+static const vec_t V4 = { .x = -4.52f, .y = -1.44f, .z = -3.0f };
+
+/* Vector nearly parallel to V3 */
+static const vec_t V5 = { .x = 7.68f, .y = 2.26f, .z = 5.0f };
+
+
 /* ##############################################################################
  * ------------------------        quat_cmp tests       -------------------------
  * ############################################################################## */
@@ -1144,4 +1151,132 @@ TEST_GROUP_RUNNER(group_quat_rotQuat)
 	RUN_TEST_CASE(group_quat_rotQuat, quat_rotQuat_baseQuaternions);
 	RUN_TEST_CASE(group_quat_rotQuat, quat_rotQuat_std);
 	RUN_TEST_CASE(group_quat_rotQuat, quat_rotQuat_zeroVector);
+}
+
+
+/* ##############################################################################
+ * ---------------------        quat_uvec2uvec tests       ----------------------
+ * ############################################################################## */
+
+
+TEST_GROUP(group_quat_uvec2uvec);
+
+
+TEST_SETUP(group_quat_uvec2uvec)
+{
+}
+
+
+TEST_TEAR_DOWN(group_quat_uvec2uvec)
+{
+}
+
+
+TEST(group_quat_uvec2uvec, quat_uvec2uvec_std)
+{
+	quat_t q;
+	vec_t v1 = V1;
+	vec_t v2 = V1rotQ8;
+
+	vec_normalize(&v1);
+	vec_normalize(&v2);
+
+	quat_uvec2uvec(&v1, &v2, &q);
+
+	/* We are not comparing `q` to `Q8`, because there is infinite number of correct quaternions, which rotates `v1` to `v2` */
+	quat_vecRot(&v1, &q);
+	TEST_ASSERT_EQUAL_VEC(v2, v1);
+}
+
+
+TEST(group_quat_uvec2uvec, quat_uvec2uvec_biggerValues)
+{
+	quat_t q;
+	vec_t v1 = V2;
+	vec_t v2 = V2rotQ8;
+
+	vec_normalize(&v1);
+	vec_normalize(&v2);
+
+	quat_uvec2uvec(&v1, &v2, &q);
+
+	quat_vecRot(&v1, &q);
+	TEST_ASSERT_EQUAL_VEC(v2, v1);
+}
+
+
+TEST(group_quat_uvec2uvec, quat_uvec2uvec_parallel)
+{
+	quat_t q, expected;
+	vec_t v1 = V2, v2;
+
+	quat_idenWrite(&expected);
+
+	/* Making `v1` and `v2` unitary and parallel */
+	vec_normalize(&v1);
+	v2 = v1;
+
+	quat_uvec2uvec(&v1, &v2, &q);
+
+	TEST_ASSERT_EQUAL_QUAT(expected, q);
+}
+
+
+TEST(group_quat_uvec2uvec, quat_uvec2uvec_antiparallel)
+{
+	quat_t q;
+	vec_t v1 = V2, v2;
+
+	/* Making `v1` and `v2` unitary and antiparallel */
+	vec_normalize(&v1);
+	v2 = v1;
+	vec_times(&v2, -1);
+
+	quat_uvec2uvec(&v1, &v2, &q);
+
+	quat_vecRot(&v1, &q);
+	TEST_ASSERT_EQUAL_VEC(v2, v1);
+}
+
+
+TEST(group_quat_uvec2uvec, quat_uvec2uvec_nearlyAntiparallel)
+{
+	quat_t q;
+	vec_t v1 = V3, v2 = V4;
+
+	vec_normalize(&v1);
+	vec_normalize(&v2);
+
+	quat_uvec2uvec(&v1, &v2, &q);
+
+	/* `v1` and `v2` are nearly antiparallel, but not enough for `quat_uvec2uvec` to be perceived as antiparallel */
+	quat_vecRot(&v1, &q);
+	TEST_ASSERT_EQUAL_VEC(v2, v1);
+}
+
+
+TEST(group_quat_uvec2uvec, quat_uvec2uvec_nearlyParallel)
+{
+	quat_t q;
+	vec_t v1 = V3, v2 = V5;
+
+	vec_normalize(&v1);
+	vec_normalize(&v2);
+
+	quat_uvec2uvec(&v1, &v2, &q);
+
+	/* `v1` and `v2` are nearly antiparallel, but not enough for `quat_uvec2uvec` to be perceived as antiparallel */
+	quat_vecRot(&v1, &q);
+	TEST_ASSERT_EQUAL_VEC(v2, v1);
+}
+
+
+TEST_GROUP_RUNNER(group_quat_uvec2uvec)
+{
+	RUN_TEST_CASE(group_quat_uvec2uvec, quat_uvec2uvec_std);
+	RUN_TEST_CASE(group_quat_uvec2uvec, quat_uvec2uvec_biggerValues);
+	RUN_TEST_CASE(group_quat_uvec2uvec, quat_uvec2uvec_parallel);
+	RUN_TEST_CASE(group_quat_uvec2uvec, quat_uvec2uvec_antiparallel);
+	RUN_TEST_CASE(group_quat_uvec2uvec, quat_uvec2uvec_nearlyAntiparallel);
+	RUN_TEST_CASE(group_quat_uvec2uvec, quat_uvec2uvec_nearlyParallel);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
In this PR I have fixed `quat_uvec2uvec` function. Now function check if passed vectors are parallel or antiparallel in a proper way. Moreover I have added tests for this function.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
More robust functions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [x] New test added: (add PR link here). In this PR
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
