### PR TITLE
calib: handle magmot calibration below cutoff

### DIFF
--- a/calib/magmot.c
+++ b/calib/magmot.c
@@ -188,7 +188,7 @@ const char *magmot_help(void)
 static int magmot_run(void)
 {
 	vec_t magBase, magCurr, magDiff;
-	float thrtl = 0, thrtlStep, startThrtl = 0.3;
+	float thrtl = 0, thrtlStep, startThrtl = MAGMOT_CUTOFF_THROTTLE;
 	float x[CALIB_POINTS], y[3][CALIB_POINTS];
 	unsigned int m, pts;
 	float (*motorEq)[3][3];

--- a/libs/calib/calib.h
+++ b/libs/calib/calib.h
@@ -19,8 +19,9 @@
 #define CALIB_PATH    "/etc/calib.conf"
 #define NUM_OF_MOTORS 4
 
-#define MAGMOT_TAG    "magmot"
-#define MAGMOT_PARAMS 36
+#define MAGMOT_TAG             "magmot"
+#define MAGMOT_PARAMS          36
+#define MAGMOT_CUTOFF_THROTTLE 0.3 /* minimal throttle value calibration is made with */
 
 #define MAGIRON_TAG     "magiron"
 #define MAGIRON_PARAMS  12


### PR DESCRIPTION


JIRA: PP-89

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Magmot calibration is done only above throttle = 0.3. Calibration calclulated below may be artificial, as it should go to 0 when throttle approach 0. Quadratic fit may have minimum somewhere between 0 and cutoff, thus artificial correction may be applied:

Changed: 
 - add cutoff macro
 - use this macro to clip calibration if throttle is below the cutoff value
 - extract motor impact calculation as inline function

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
