### PR TITLE
Adding `quat_rotQuat` function

### DIFF
--- a/algebra/include/quat.h
+++ b/algebra/include/quat.h
@@ -103,6 +103,10 @@ extern void quat_uvec2uvec(const vec_t *v1, const vec_t *v2, quat_t *q);
 extern void quat_vecRot(vec_t *vec, const quat_t *qRot);
 
 
+/* calculate quaternion, which rotates about `angle` in radians along `axis` */
+extern void quat_rotQuat(const vec_t *axis, float angle, quat_t *q);
+
+
 /* calculates quaternion res (closest to help_q), that rotates frame of reference (v1, v2) into (w1, w2) */
 extern void quat_frameRot(const vec_t *v1, const vec_t *v2, const vec_t *w1, const vec_t *w2, quat_t *res, const quat_t *help_q);
 

--- a/algebra/quat.c
+++ b/algebra/quat.c
@@ -182,6 +182,26 @@ void quat_vecRot(vec_t *vec, const quat_t *qRot)
 }
 
 
+void quat_rotQuat(const vec_t *axis, float angle, quat_t *q)
+{
+	float coeff, len;
+
+	len = vec_len(axis);
+
+	if (len == 0) {
+		quat_idenWrite(q);
+		return;
+	}
+
+	coeff = sinf(angle / 2) / len;
+
+	q->a = cosf(angle / 2);
+	q->i = axis->x * coeff;
+	q->j = axis->y * coeff;
+	q->k = axis->z * coeff;
+}
+
+
 void quat_frameRot(const vec_t *v1, const vec_t *v2, const vec_t *w1, const vec_t *w2, quat_t *res, const quat_t *help_q)
 {
 	vec_t n, p;

--- a/algebra/tests/main.c
+++ b/algebra/tests/main.c
@@ -66,6 +66,7 @@ void runner(void)
 	RUN_TEST_GROUP(group_quat_normalize);
 	RUN_TEST_GROUP(group_quat_quat2euler);
 	RUN_TEST_GROUP(group_quat_vecRot);
+	RUN_TEST_GROUP(group_quat_rotQuat);
 }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
This PR adds new function `quat_axisAngle2quat` to `quat` libary. Function return quaternion which represents rotation along defined axis and about defined angle. Moreover I have added tests for this function.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Better interface for quaternions operations.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [x] New test added: (add PR link here). In this PR
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
