### PR TITLE
Adding tests and fixing `quat_frameRot` function

### DIFF
--- a/algebra/include/quat.h
+++ b/algebra/include/quat.h
@@ -95,7 +95,7 @@ extern void quat_times(quat_t *A, float x);
 extern void quat_quat2euler(const quat_t *q, float *roll, float *pitch, float *yaw);
 
 
-/* calculate quaternion q that rotates v1 into v2. `v1` and `v2` need to be unit vectors */
+/* calculate quaternion q that rotates v1 into v2 along axis perpendicular to `v1` and `v2`. Both vectors need to be unit vectors */
 extern void quat_uvec2uvec(const vec_t *v1, const vec_t *v2, quat_t *q);
 
 

--- a/algebra/tests/main.c
+++ b/algebra/tests/main.c
@@ -68,6 +68,7 @@ void runner(void)
 	RUN_TEST_GROUP(group_quat_vecRot);
 	RUN_TEST_GROUP(group_quat_rotQuat);
 	RUN_TEST_GROUP(group_quat_uvec2uvec);
+	RUN_TEST_GROUP(group_quat_frameRot);
 }
 
 

--- a/algebra/vec.c
+++ b/algebra/vec.c
@@ -80,7 +80,7 @@ float vec_len(const vec_t *A)
 void vec_normal(const vec_t *A, const vec_t *B, vec_t *C)
 {
 	float lenSquared;
-	vec_t v = { .x = 1.0f, .y = 0.0f, .y = 0.0f, .z = 0.0f };
+	vec_t v = { .x = 1.0f, .y = 0.0f, .z = 0.0f };
 	const vec_t *longerV;
 
 	vec_cross(A, B, C);
@@ -91,7 +91,6 @@ void vec_normal(const vec_t *A, const vec_t *B, vec_t *C)
 		return;
 	}
 	/* First `vec_cross` returned zero vector. `A` and `B` are parallel, or there is at least one zero vector. */
-
 	longerV = (vec_dot(A, A) > vec_dot(B, B)) ? A : B;
 
 	vec_cross(longerV, &v, C);
@@ -102,7 +101,6 @@ void vec_normal(const vec_t *A, const vec_t *B, vec_t *C)
 		return;
 	}
 	/* Second `vec_cross` returned zero vector. Longer of `A` and `B` must be parallel to `v` or be a zero vector. */
-
 	v.z = 1;
 
 	vec_cross(longerV, &v, C);
@@ -123,7 +121,7 @@ void vec_normal(const vec_t *A, const vec_t *B, vec_t *C)
 void vec_normalize(vec_t *A)
 {
 	float len = A->x * A->x + A->y * A->y + A->z * A->z;
-	len = sqrt(len); /* FIXME: fast iverse square needed here! */
+	len = sqrt(len); /* FIXME: fast inverse square needed here! */
 
 	A->x /= len;
 	A->y /= len;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
In this PR fixes `quat_frameRot` function. No function is able to handle situation when second vector from frame of reference are parallel to each other. Moreover I have added tests to cover my changes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixing potential problem

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [x] New test added: (add PR link here). In this PR
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
