### PR TITLE
algebra: fixing `matrix_bufAlloc` function

### DIFF
--- a/algebra/matrix.c
+++ b/algebra/matrix.c
@@ -26,6 +26,10 @@ int matrix_bufAlloc(matrix_t *matrix, unsigned int rows, unsigned int cols)
 {
 	float *data;
 
+	if (rows == 0 || cols == 0) {
+		return -1;
+	}
+
 	/* check for calloc 'nitems' overflow */
 	if (SIZE_MAX / rows < cols) {
 		return -1;


### PR DESCRIPTION
JIRA: PP-71

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Now function checks explicitly  if passed number of `rows` and `cols` are not equal to 0. This make this function less implementation dependent, because according to POSIX `calloc` can, but don't have to fail when gets zero elements to allocate.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Less implementation dependent function.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here). `armv7a9-zynq7000-qemu`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
