### PR TITLE
Make `matrix` libarary tests more precise

### DIFF
--- a/algebra/tests/matrix/add_sub.c
+++ b/algebra/tests/matrix/add_sub.c
@@ -56,8 +56,9 @@ TEST_SETUP(group_matrix_add_stdMat)
 		}
 	}
 
-	/* Allocating matrix for results */
+	/* Allocating matrix for results and filling with non zero data */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M3, Expected.rows, Expected.cols));
+	algebraTests_buffFill(&M3, initVal, initValLen);
 }
 
 
@@ -237,8 +238,9 @@ TEST_SETUP(group_matrix_add_bigMat)
 		}
 	}
 
-	/* Allocating matrix for results */
+	/* Allocating matrix for results and filling with non zero data */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M3, Expected.rows, Expected.cols));
+	algebraTests_buffFill(&M3, initVal, initValLen);
 
 	M4.data = NULL;
 	M5.data = NULL;
@@ -615,8 +617,9 @@ TEST_SETUP(group_matrix_sub_stdMat)
 		}
 	}
 
-	/* Allocating matrix for results */
+	/* Allocating matrix for results and filling with non zero data */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M3, Expected.rows, Expected.cols));
+	algebraTests_buffFill(&M3, initVal, initValLen);
 }
 
 
@@ -796,8 +799,9 @@ TEST_SETUP(group_matrix_sub_bigMat)
 		}
 	}
 
-	/* Allocating matrix for results */
+	/* Allocating matrix for results and filling with non zero data */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M3, Expected.rows, Expected.cols));
+	algebraTests_buffFill(&M3, initVal, initValLen);
 
 	M4.data = NULL;
 	M5.data = NULL;

--- a/algebra/tests/matrix/buffs.h
+++ b/algebra/tests/matrix/buffs.h
@@ -16,6 +16,10 @@
 
 /* clang-format off */
 
+/* Value for initiating matrices. Must be different than zero and one. */
+static const float initVal[] = {4.5f};
+static const int initValLen = 1;
+
 /* A - small square matrix with integer values */
 static const unsigned int buffs_rowsA = 3, buffs_colsA = 3;
 

--- a/algebra/tests/matrix/inverse.c
+++ b/algebra/tests/matrix/inverse.c
@@ -48,8 +48,9 @@ TEST_SETUP(group_matrix_inv_stdMat)
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK,
 		algebraTests_createAndFill(&Expected, buffs_rowsInvA, buffs_colsInvA, buffs_invA, buffs_colsInvA * buffs_rowsInvA));
 
-	/* Allocating result matrix */
+	/* Allocating matrix for results and filling with non zero data */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M2, Expected.rows, Expected.cols));
+	algebraTests_buffFill(&M2, initVal, initValLen);
 
 	bufLen = M1.rows * M1.cols * 2;
 	buf = malloc(sizeof(float) * bufLen);
@@ -149,8 +150,9 @@ TEST_SETUP(group_matrix_inv_bigMat)
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK,
 		algebraTests_createAndFill(&M1, buffs_rowsJ, buffs_colsJ, buffs_J, buffs_colsJ * buffs_rowsJ));
 
-	/* Allocating result matrix */
+	/* Allocating matrix for results and filling with non zero data */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M2, M1.rows, M1.cols));
+	algebraTests_buffFill(&M2, initVal, initValLen);
 
 	/* Allocating temporary matrix */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M3, M1.rows, M1.cols));
@@ -268,8 +270,9 @@ TEST(group_matrix_inv_otherMats, matrix_inv_zeroOnDiag)
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK,
 		algebraTests_createAndFill(&Expected, buffs_rowsInvK, buffs_colsInvK, buffs_invK, buffs_colsInvK * buffs_rowsInvK));
 
-	/* Allocating result matrix */
+	/* Allocating matrix for results and filling with non zero data */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M2, Expected.rows, Expected.cols));
+	algebraTests_buffFill(&M2, initVal, initValLen);
 
 	bufLen = M1.rows * M1.cols * 2;
 	buf = malloc(sizeof(float) * bufLen);
@@ -299,8 +302,9 @@ TEST_SETUP(group_matrix_inv_badMat)
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK,
 		algebraTests_createAndFill(&M1, buffs_rowsJ, buffs_colsJ, buffs_J, buffs_colsJ * buffs_rowsJ));
 
-	/* Allocating result matrix */
+	/* Allocating matrix for results and filling with non zero data */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M2, M1.rows, M1.cols));
+	algebraTests_buffFill(&M2, initVal, initValLen);
 
 	bufLen = M1.rows * M1.cols * 2;
 	buf = malloc(sizeof(float) * bufLen);

--- a/algebra/tests/matrix/mulitiplication.c
+++ b/algebra/tests/matrix/mulitiplication.c
@@ -48,8 +48,9 @@ TEST_SETUP(group_matrix_prod_stdMat)
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK,
 		algebraTests_createAndFill(&Expected, buffs_rowsCtimesD, buffs_colsCtimesD, buffs_CtimesD, buffs_colsCtimesD * buffs_rowsCtimesD));
 
-	/* Allocating matrix for results */
+	/* Allocating matrix for results and filling with non zero data */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M3, Expected.rows, Expected.cols));
+	algebraTests_buffFill(&M3, initVal, initValLen);
 }
 
 
@@ -163,8 +164,9 @@ TEST_SETUP(group_matrix_prod_bigMat)
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK,
 		algebraTests_createAndFill(&Expected, buffs_rowsEtimesF, buffs_colsEtimesF, buffs_EtimesF, buffs_colsEtimesF * buffs_rowsEtimesF));
 
-	/* Allocating matrix for results */
+	/* Allocating matrix for results and filling with non zero data */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M3, Expected.rows, Expected.cols));
+	algebraTests_buffFill(&M3, initVal, initValLen);
 
 	M4.data = NULL;
 	M5.data = NULL;
@@ -416,8 +418,9 @@ TEST_SETUP(group_matrix_sparseProd_stdMat)
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK,
 		algebraTests_createAndFill(&Expected, buffs_rowsCtimesD, buffs_colsCtimesD, buffs_CtimesD, buffs_colsCtimesD * buffs_rowsCtimesD));
 
-	/* Allocating matrix for results */
+	/* Allocating matrix for results and filling with non zero data */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M3, Expected.rows, Expected.cols));
+	algebraTests_buffFill(&M3, initVal, initValLen);
 }
 
 
@@ -531,8 +534,9 @@ TEST_SETUP(group_matrix_sparseProd_bigMat)
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK,
 		algebraTests_createAndFill(&Expected, buffs_rowsEtimesF, buffs_colsEtimesF, buffs_EtimesF, buffs_colsEtimesF * buffs_rowsEtimesF));
 
-	/* Allocating matrix for results */
+	/* Allocating matrix for results and filling with non zero data */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M3, Expected.rows, Expected.cols));
+	algebraTests_buffFill(&M3, initVal, initValLen);
 
 	M4.data = NULL;
 	M5.data = NULL;

--- a/algebra/tests/matrix/sandwitch.c
+++ b/algebra/tests/matrix/sandwitch.c
@@ -50,8 +50,9 @@ TEST_SETUP(group_matrix_sandwitch_stdMat)
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK,
 		algebraTests_createAndFill(&Expected, buffs_rowsAsandB, buffs_colsAsandB, buffs_AsandB, buffs_colsAsandB * buffs_rowsAsandB));
 
-	/* Allocating matrix for results */
+	/* Allocating matrix for results and filling with non zero data */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M3, Expected.rows, Expected.cols));
+	algebraTests_buffFill(&M3, initVal, initValLen);
 
 	/* Allocating temporary matrix */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&tmp, M1.rows, M2.cols));
@@ -169,8 +170,9 @@ TEST_SETUP(group_matrix_sandwitch_bigMat)
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK,
 		algebraTests_createAndFill(&Expected, buffs_rowsGsandH, buffs_colsGsandH, buffs_GsandH, buffs_colsGsandH * buffs_rowsGsandH));
 
-	/* Allocating matrix for results */
+	/* Allocating matrix for results and filling with non zero data */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M3, Expected.rows, Expected.cols));
+	algebraTests_buffFill(&M3, initVal, initValLen);
 
 	/* Allocating temporary matrix */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&tmp, M1.rows, M2.cols));
@@ -456,8 +458,9 @@ TEST_SETUP(group_matrix_sparseSandwitch_stdMat)
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK,
 		algebraTests_createAndFill(&Expected, buffs_rowsAsandB, buffs_colsAsandB, buffs_AsandB, buffs_colsAsandB * buffs_rowsAsandB));
 
-	/* Allocating matrix for results */
+	/* Allocating matrix for results and filling with non zero data */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M3, Expected.rows, Expected.cols));
+	algebraTests_buffFill(&M3, initVal, initValLen);
 
 	/* Allocating temporary matrix */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&tmp, M1.rows, M2.cols));
@@ -574,8 +577,9 @@ TEST_SETUP(group_matrix_sparseSandwitch_bigMat)
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK,
 		algebraTests_createAndFill(&Expected, buffs_rowsGsandH, buffs_colsGsandH, buffs_GsandH, buffs_colsGsandH * buffs_rowsGsandH));
 
-	/* Allocating matrix for results */
+	/* Allocating matrix for results and filling with non zero data */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M3, Expected.rows, Expected.cols));
+	algebraTests_buffFill(&M3, initVal, initValLen);
 
 	/* Allocating temporary matrix */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&tmp, M1.rows, M2.cols));

--- a/algebra/tests/matrix/various.c
+++ b/algebra/tests/matrix/various.c
@@ -38,10 +38,6 @@ static matrix_t stMat = { .data = buf, .cols = COLS, .rows = ROWS, .transposed =
 static matrix_t M1, M2, M3;
 
 
-/* Must be different than zero and one */
-static float initVal[] = { 2.0 };
-static int initValLen = 1;
-
 /* ##############################################################################
  * -----------------------        matrix_trp tests       ------------------------
  * ############################################################################## */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
This PR changes tests of `matrix` library so that matrices for result have no elements equal to zero.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug was found which in `matrix_sparseProd` function when result matrix had non zero elements. This change is made for preventing such a mistakes in the future.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here). `armv7a9-zynq7000-qemu`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
