### PR TITLE
ekf: `qEst` sign fix

### DIFF
--- a/ekf/kalman_update_imu.c
+++ b/ekf/kalman_update_imu.c
@@ -100,10 +100,14 @@ static matrix_t *getMeasurement(matrix_t *Z, matrix_t *state, matrix_t *R, time_
 	Z->data[immy] = mag.y;
 	Z->data[immz] = mag.z;
 
+	/*
+	* qEst rotates vectors from body frame base to NED base.
+	* We store the body frame rotation which is conjugation of qEst.
+	*/
 	Z->data[imqa] = qEst.a;
-	Z->data[imqb] = qEst.i;
-	Z->data[imqc] = qEst.j;
-	Z->data[imqd] = qEst.k;
+	Z->data[imqb] = -qEst.i;
+	Z->data[imqc] = -qEst.j;
+	Z->data[imqd] = -qEst.k;
 
 	/* update measurement error */
 	R->data[R->cols * imqa + imqa] = qEstErr;


### PR DESCRIPTION
JIRA: PP-105

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes 
qEst rotates vectors from body frame base to NED . In ekf we store the body frame rotation which is conjugation of qEst.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
