### PR TITLE
`hmap` fix

### DIFF
--- a/libs/hmap/hmap.c
+++ b/libs/hmap/hmap.c
@@ -109,6 +109,13 @@ int hmap_insert(hmap_t *hm, const char *key, void *val)
 	if (hm->arr[i].value != NULL) {
 		/* traverse hashmap to find next free bucket */
 		do {
+			if (hash == hm->arr[i].hash) {
+				if (strcmp(key, hm->arr[i].key) == 0) {
+					/* There is already an entry with such a key */
+					return -1;
+				}
+			}
+
 			if (++i == hm->capacity) {
 				i = 0;
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Function `hmap_insert` fails if there is already an entry with same key as we want to add.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixing incorrect behavior.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here). `armv7a9-zynq7000-qemu`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
