### PR TITLE
quadcontrol: fix abort in control.c

### DIFF
--- a/ekf/ekflib.h
+++ b/ekf/ekflib.h
@@ -42,13 +42,21 @@ typedef struct {
 	float accelZ;
 } ekf_state_t;
 
+
 extern int ekf_init(void);
+
 
 extern int ekf_run(void);
 
+
+extern void ekf_stop(void);
+
+
 extern void ekf_done(void);
 
+
 extern void ekf_stateGet(ekf_state_t *ekf_state);
+
 
 extern void ekf_boundsGet(float *bYaw, float *bRoll, float *bPitch);
 

--- a/libs/rcbus/rcbus.c
+++ b/libs/rcbus/rcbus.c
@@ -201,13 +201,17 @@ int rcbus_run(RcMsgHandler handler, time_t timeout)
 }
 
 
-void rcbus_done(void)
+void rcbus_stop(void)
 {
 	rcbus_common.run = 0;
 
 	/* FIXME: add tid to threadJoin function, after merge in libphoenix */
 	threadJoin(0);
+}
 
+
+void rcbus_done(void)
+{
 	close(rcbus_common.fd);
 }
 

--- a/libs/rcbus/rcbus.h
+++ b/libs/rcbus/rcbus.h
@@ -36,7 +36,11 @@ typedef void (*RcMsgHandler)(const rcbus_msg_t *msg);
 extern int rcbus_run(RcMsgHandler handler, time_t timeout);
 
 
-/* Close reading thread and close communication with a device. */
+/* Close reading thread */
+extern void rcbus_stop(void);
+
+
+/* Close communication with a device. */
 extern void rcbus_done(void);
 
 

--- a/quadcontrol/control.c
+++ b/quadcontrol/control.c
@@ -378,6 +378,7 @@ static int quad_run(void)
 			quad_common.currFlight = quad_common.scenario[i].type;
 		}
 
+
 		log_enable();
 		switch (quad_common.currFlight) {
 			/* Handling basic modes */
@@ -728,6 +729,7 @@ static int quad_configRead(void)
 
 static void quad_done(void)
 {
+	mma_stop();
 	mma_done();
 	ekf_done();
 	rcbus_done();
@@ -795,14 +797,6 @@ static int quad_init(void)
 		return -1;
 	}
 
-	if (rcbus_run(quad_rcbusHandler, 500) < 0) {
-		fprintf(stderr, "quadcontrol: cannot run rcbus\n");
-		resourceDestroy(quad_common.rcbusLock);
-		free(quad_common.scenario);
-		return -1;
-	}
-
-
 	/* EKF initialization */
 	if (ekf_init() < 0) {
 		fprintf(stderr, "quadcontrol: cannot initialize ekf\n");
@@ -810,18 +804,6 @@ static int quad_init(void)
 		free(quad_common.scenario);
 		return -1;
 	}
-
-
-	if (ekf_run() < 0) {
-		fprintf(stderr, "quadcontrol: cannot run ekf\n");
-		resourceDestroy(quad_common.rcbusLock);
-		free(quad_common.scenario);
-		return -1;
-	}
-
-
-	/* EKF needs time to calibrate itself */
-	sleep(10);
 
 	return 0;
 }
@@ -888,7 +870,7 @@ int main(int argc, char **argv)
 	signal(SIGQUIT, SIG_IGN);
 	signal(SIGTERM, SIG_IGN);
 
-	pid = vfork();
+	pid = fork();
 	/* Parent process waits on child and makes clean up  */
 	if (pid > 0) {
 		do {
@@ -904,17 +886,40 @@ int main(int argc, char **argv)
 		/* Take terminal control */
 		tcsetpgrp(STDIN_FILENO, getpid());
 
+		if (rcbus_run(quad_rcbusHandler, 500) < 0) {
+			fprintf(stderr, "quadcontrol: cannot run rcbus\n");
+			quad_done();
+			exit(EXIT_FAILURE);
+		}
+
+		if (ekf_run() < 0) {
+			fprintf(stderr, "quadcontrol: cannot run ekf\n");
+			rcbus_stop();
+			quad_done();
+			exit(EXIT_FAILURE);
+		}
+
+
 		quad_run();
+
+		/* Stop threads from external libs */
+		ekf_stop();
+		rcbus_stop();
+
+		quad_done();
+
 		exit(EXIT_SUCCESS);
 	}
 	else {
 		fprintf(stderr, "quadcontrol: vfork failed with code %d\n", pid);
 	}
 
+
 	quad_done();
 
 	/* Take back terminal control */
 	tcsetpgrp(STDIN_FILENO, getpid());
+
 
 	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
ekf and rcbus thread have been located in parent's process map. It can caused an undefined behavior.
`fork` is used instead of `vfork`.

All threads all moved to the child process.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (zturn-pilot).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
