### PR TITLE
ekf: new math model (simplified to attitude and gyro bias)

### DIFF
--- a/ekf/Makefile
+++ b/ekf/Makefile
@@ -5,7 +5,7 @@
 #
 
 # Files structures
-KALMAN_SRCS := kalman_implem.c kalman_core.c kalman_update_imu.c kalman_update_baro.c kalman_update_gps.c
+KALMAN_SRCS := kalman_implem.c kalman_core.c kalman_update_imu.c
 
 # EKF library
 NAME := libekf

--- a/ekf/meas.c
+++ b/ekf/meas.c
@@ -305,9 +305,6 @@ int meas_imuGet(vec_t *accels, vec_t *gyros, vec_t *mags, uint64_t *timestamp)
 
 	meas_ellipCompensate(accels, accCalib);
 
-	/* gyro niveling */
-	vec_sub(gyros, &meas_common.calib.imu.gyroBias);
-
 	fltr_accLpf(accels);
 	//fltr_gyrLpf(gyros);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
- new ekf math model estimates only attitude quaternion and gyro bias (however in first step it is taken as constant value),
- ekf implementation is cleared from name-dependent define-s
- direct matrix-memory access is used only on column matrices, and access to multi-row/column matrices is done using proper access function `*matrix_at()`
- not estimated ekf parameters available in ekf API (e.g velocity) is zeroed to not disrupt higher level clients of ekf data

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Following changes allow for:
 - consistent math model for Kalman filter with no math shortcuts that are in no way possible to write as equations
 - will allow for smooth fly when gyroscope bias estimation will be satisfactory

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (ztirn drone in cage).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
