### PR TITLE
quad-control: pid attenuation and log dropping

### DIFF
--- a/quadcontrol/config.h
+++ b/quadcontrol/config.h
@@ -16,6 +16,7 @@
 
 #include "control.h"
 #include "pid.h"
+#include "mma.h"
 
 
 /* Parses file from `path` with saved mission scenario. If succeeded returns 0 and `scenario` is array with length equal to `sz`. In other case returns -1.  */
@@ -33,5 +34,8 @@ extern int config_throttleRead(const char *path, quad_throttle_t **throttle, int
 /* Parser all attitude config structures from file defined by `path`. If succeeded returns 0 and `attitude` is array with length equal to `sz`. In other case returns -1. */
 extern int config_attitudeRead(const char *path, quad_att_t **attitude, int *sz);
 
+
+/* Parses attenuation config structures from file defined by `path`. If succeeded returns 0 and `atten` is array with length equal to one. In other case returns -1. */
+extern int config_attenRead(const char *path, mma_atten_t **atten, int *sz);
 
 #endif

--- a/quadcontrol/control.c
+++ b/quadcontrol/control.c
@@ -166,14 +166,11 @@ static int quad_motorsCtrl(float throttle, int32_t alt, const quad_att_t *att, c
 
 	log_print("EKFE: %lld %.1f %.1f %.1f\n", now, measure->yaw * RAD2DEG, measure->pitch * RAD2DEG, measure->roll * RAD2DEG);
 	log_print("EKFX: %.2f %.2f\n", measure->enuZ, measure->veloZ);
-	log_print("PID: ");
-
 
 	palt = pid_calc(&quad_common.pids[pwm_alt], alt / 1000.f, measure->enuZ, measure->veloZ, dt);
 	proll = pid_calc(&quad_common.pids[pwm_roll], att->roll, measure->roll, measure->rollDot, dt);
 	ppitch = pid_calc(&quad_common.pids[pwm_pitch], att->pitch, measure->pitch, measure->pitchDot, dt);
 	pyaw = pid_calc(&quad_common.pids[pwm_yaw], att->yaw, measure->yaw, measure->yawDot, dt);
-	log_print("\n");
 
 	if (mma_control(throttle + palt, proll, ppitch, pyaw) < 0) {
 		return -1;

--- a/quadcontrol/control.c
+++ b/quadcontrol/control.c
@@ -62,7 +62,7 @@
 #define RC_OVRD_THROTTLE (1 << 2)
 
 #define ABORT_FRAMES_THRESH 5 /* number of correct abort frames from RC transmitter to initiate abort sequence */
-#define LOG_PERIOD 100        /* drone control loop logs data once per 'LOG_PERIOD' milliseconds */
+#define LOG_PERIOD 1000        /* drone control loop logs data once per 'LOG_PERIOD' milliseconds */
 
 /* Flight modes magic numbers */
 #define QCTRL_ALTHOLD_JUMP   5000  /* altitude step (millimeters) for two-height althold mode in quad_manual */
@@ -162,7 +162,6 @@ static int quad_motorsCtrl(float throttle, int32_t alt, const quad_att_t *att, c
 
 	dt = now - quad_common.lastTime;
 	quad_common.lastTime = now;
-
 
 	log_print("EKFE: %lld %.1f %.1f %.1f\n", now, measure->yaw * RAD2DEG, measure->pitch * RAD2DEG, measure->roll * RAD2DEG);
 	log_print("EKFX: %.2f %.2f\n", measure->enuZ, measure->veloZ);

--- a/quadcontrol/mma.c
+++ b/quadcontrol/mma.c
@@ -93,12 +93,6 @@ int mma_control(float palt, float proll, float ppitch, float pyaw)
 		return -1;
 	}
 
-	/*
-	* Printing PWM before per-motor calibration
-	* We want information about pid impact on control step, not hardware step
-	*/
-	log_print("PWM: %.3f %.3f %.3f %.3f\n", pwm[0], pwm[1], pwm[2], pwm[3]);
-
 	for (i = 0; i < NUMBER_MOTORS; ++i) {
 		mma_calib(&pwm[i], i);
 

--- a/quadcontrol/mma.h
+++ b/quadcontrol/mma.h
@@ -16,6 +16,21 @@
 
 #include "control.h"
 
+/*
+Pid input attenuation factor is relative to throttle.
+Factor curve has three points (throttle, factor): [ (0, startVal), (midArg, midVal), (1, enfVal) ]
+Middle point of attenuation must be within (0.1, 0.9) throttle range.
+Attenuation factor values must be within (0, 2) range
+*/
+typedef struct {
+	float startVal; /* attenuation curve value at throttle = 0 */
+	float midArg;	/* attenuation curve middle point */
+	float midVal;	/* attenuation curve value at throttle = midArg */
+	float endVal;	/* attenuation curve value at throttle = 1 */
+
+	float slope[2]; /* Slopes of attenuation curve. [0] for start-mid, [1] for mid-end curve */
+} mma_atten_t;
+
 
 /* Based on PID values, the PWM are set to the each motor */
 extern int mma_control(float palt, float proll, float ppitch, float pyaw);
@@ -34,7 +49,7 @@ extern void mma_done(void);
 
 
 /* MMA module initialization */
-extern int mma_init(const quad_coeffs_t *coeffs);
+extern int mma_init(const quad_coeffs_t *coeffs, const mma_atten_t *atten);
 
 
 #endif

--- a/quadcontrol/pid.c
+++ b/quadcontrol/pid.c
@@ -78,8 +78,6 @@ float pid_calc(pid_ctx_t *pid, float setVal, float currVal, float currValDot, ti
 	pid->prevErr = err;
 	pid->lastPid = out;
 
-	log_print("%.4f %.4f %.4f %.4f ", p, i, d, out);
-
 	return out;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Two changes in this PR:
 - partially dropping logging of quad-control as it is less usable now and takes time to print (lowers loop efficiency)
 - implementing pid attenuation:
   - pid values attenuation happens accordingly to attenuation factor
   - pid values are straight multiplied by attenuation factor
   - attenuation factor is calculated based on current throttle and attenuation factor curve specified by user
   - attenuation factor curve has 3 points:
     1) at throttle equal 0 and of `startVal` value
     2) at throttle equal `startVal` and of `startVal` value
     3) at throttle equal 1 and of `startVal` value 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: zturn drone.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
