### PR TITLE
Fix problem with parsing file without required header

### DIFF
--- a/quadcontrol/config.c
+++ b/quadcontrol/config.c
@@ -113,6 +113,16 @@ static int config_trimUnusedData(int parserType, size_t dataTypeSize)
 {
 	void *tmp;
 
+	/* Due to implementation-defined behavior of realloc when space requested is zero */
+	if (res[parserType].invCnt == 0) {
+		free(res[parserType].data);
+		res[parserType].data = NULL;
+		res[parserType].sz = 0;
+
+		/* Returns zero, because not finding a header in particular file is not an error */
+		return 0;
+	}
+
 	if (res[parserType].invCnt < res[parserType].sz) {
 		tmp = realloc(res[parserType].data, dataTypeSize * res[parserType].invCnt);
 		if (tmp == NULL) {

--- a/quadcontrol/control.c
+++ b/quadcontrol/control.c
@@ -713,7 +713,7 @@ static int quad_config(void)
 	}
 
 	if (res != PID_NUMBERS) {
-		fprintf(stderr, "quadcontrol: wrong number of PIDs in %s", PATH_QUAD_CONFIG);
+		fprintf(stderr, "quadcontrol: wrong number of PIDs in %s\n", PATH_QUAD_CONFIG);
 		free(quad_common.pids);
 		return -1;
 	}
@@ -726,7 +726,7 @@ static int quad_config(void)
 	}
 
 	if (res != 1) {
-		fprintf(stderr, "quadcontrol: wrong number of throttle configs in %s", PATH_QUAD_CONFIG);
+		fprintf(stderr, "quadcontrol: wrong number of throttle configs in %s\n", PATH_QUAD_CONFIG);
 		free(quad_common.pids);
 		free(throttleTmp);
 		return -1;
@@ -743,7 +743,7 @@ static int quad_config(void)
 	}
 
 	if (res != 1) {
-		fprintf(stderr, "quadcontrol: wrong number of attenuation configs in %s", PATH_QUAD_CONFIG);
+		fprintf(stderr, "quadcontrol: wrong number of attenuation configs in %s\n", PATH_QUAD_CONFIG);
 		free(quad_common.pids);
 		free(attenTmp);
 		return -1;
@@ -760,7 +760,7 @@ static int quad_config(void)
 	}
 
 	if (res != 1) {
-		fprintf(stderr, "quadcontrol: wrong number of attitude configs in %s", PATH_QUAD_CONFIG);
+		fprintf(stderr, "quadcontrol: wrong number of attitude configs in %s\n", PATH_QUAD_CONFIG);
 		free(quad_common.pids);
 		free(attTmp);
 		return -1;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
This PR fixes a problem with parsing files without the required header. As specified in `realloc` POSIX documentation when new size is equal to zero, function can return NULL. Previously this took place in `config_trimUnusedSpace`. As a result, this function returned an error and the caller function tried to free result data, which already was freed.

Additionally, all error messages now have a newline character at the end.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Report invalid file in a proper way.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here). `armv7a9-zynq7000-qemu`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
