### PR TITLE
algebra: add quaternion-vector differentiation library

### DIFF
--- a/algebra/Makefile
+++ b/algebra/Makefile
@@ -9,5 +9,5 @@
 #
 
 NAME := libalgeb
-LOCAL_SRCS := vec.c quat.c matrix.c
+LOCAL_SRCS := vec.c quat.c matrix.c qdiff.c
 include $(static-lib.mk)

--- a/algebra/include/matrix.h
+++ b/algebra/include/matrix.h
@@ -23,6 +23,11 @@ typedef struct {
 	float *data;
 } matrix_t;
 
+
+/* Direct access macro. works only for untransposed matrices */
+#define MATRIX_DATA(m, x, y) (m)->data[((x) * (m)->cols) + (y)]
+
+
 /* sets all matrix to zeroes */
 extern void matrix_zeroes(matrix_t *A);
 

--- a/algebra/include/qdiff.h
+++ b/algebra/include/qdiff.h
@@ -1,0 +1,53 @@
+/*
+ * Phoenix-Pilot
+ *
+ * qdiff - quaternion-vector operations derivatives
+ *
+ * Copyright 2023 Phoenix Systems
+ * Author: Mateusz Niewiadomski
+ *
+ * This file is part of Phoenix-Pilot software
+ *
+ * %LICENSE%
+ */
+
+#ifndef PHOENIX_QVDIFF_H_
+#define PHOENIX_QVDIFF_H_
+
+
+#include <matrix.h>
+#include <vec.h>
+#include <quat.h>
+
+
+/* Calculates derivative: d(q * p *cjg(q)) / dq with assumptions:
+* 1) `out` is 3x4 matrix
+* 2) `q` is rotation quaternion
+* 3) `p` is vector (or pure quaternion vectorial part)
+*/
+int qvdiff_qvqDiffQ(const quat_t *q, const vec_t *v, matrix_t *out);
+
+
+/* Calculates derivative: d(q * p * cjg(q)) / d(p) with assumptions:
+* 1) `out` is 3x3, untransposed matrix
+* 2) q is quaternion
+* Note: this derivative does not need value of `p`
+*/
+int qvdiff_qvqDiffV(const quat_t *q, matrix_t *out);
+
+
+/* Calculates derivative: d(q * p) / d(q) with assumptions:
+ * 1) `out` is 4x4 matrix
+ * 2) 'q' and 'w' are quaternions
+*/
+int qvdiff_qpDiffQ(quat_t *p, matrix_t *out);
+
+
+/* Calculates derivative: d(q * w) / d(q) with assumptions:
+ * 1) `out` is 4x3 matrix
+ * 2) 'q' is a quaternion
+ * 3) 'w' is a quaternionized vector (only imaginary terms are significant)
+*/
+int qvdiff_qpDiffP(const quat_t *q, matrix_t *out);
+
+#endif

--- a/algebra/qdiff.c
+++ b/algebra/qdiff.c
@@ -1,0 +1,178 @@
+/*
+ * Phoenix-Pilot
+ *
+ * qdiff - quaternion-vector operations derivatives
+ *
+ * Copyright 2023 Phoenix Systems
+ * Author: Mateusz Niewiadomski
+ *
+ * This file is part of Phoenix-Pilot software
+ *
+ * %LICENSE%
+ */
+
+
+#include <vec.h>
+#include <matrix.h>
+#include <quat.h>
+
+
+/* Calculates cross product matrix for vector v so that when left-hand-multiplied by a vector p produces cross product (v x p).
+* `out` is assumed to be 3x3, untransposed matrix.
+*/
+static void qvdiff_crossMat(const vec_t *v, matrix_t *out)
+{
+	/* diagonal */
+	MATRIX_DATA(out, 0, 0) = 0;
+	MATRIX_DATA(out, 1, 1) = 0;
+	MATRIX_DATA(out, 2, 2) = 0;
+
+	/* upper/lower triangles */
+	MATRIX_DATA(out, 2, 1) = v->x;
+	MATRIX_DATA(out, 1, 2) = -v->x;
+	MATRIX_DATA(out, 0, 2) = v->y;
+	MATRIX_DATA(out, 2, 0) = -v->y;
+	MATRIX_DATA(out, 1, 0) = v->z;
+	MATRIX_DATA(out, 0, 1) = -v->z;
+}
+
+
+int qvdiff_qvqDiffQ(const quat_t *q, const vec_t *v, matrix_t *out)
+{
+	float vCrossData[3 * 3] = { 0 };
+	float buffData[3 * 3] = { 0 };
+	float tmp;
+
+	if (matrix_rowsGet(out) != 3 || matrix_colsGet(out) != 4 || out->transposed != 0) {
+		return -1;
+	}
+
+	/* Matrices for cross matrix of p and general matrix for the part of derivative over imaginary components of q */
+	matrix_t vCross = { .data = vCrossData, .rows = 3, .cols = 3, .transposed = 0 };
+	matrix_t buf = { .data = buffData, .rows = 3, .cols = 3, .transposed = 0 };
+
+	/* Vector for cross product (p x q) */
+	const vec_t qVec = { .x = q->i, .y = q->j, .z = q->k };
+	vec_t vxq;
+
+	vec_cross(v, &qVec, &vxq);
+
+	qvdiff_crossMat(v, &vCross);
+	qvdiff_crossMat(&vxq, &buf);
+
+	matrix_times(&vCross, q->a);
+	matrix_sub(&buf, &vCross, NULL); /* discarding return value as assumptions are met */
+	tmp = vec_dot(v, &qVec);
+	MATRIX_DATA(&buf, 0, 0) = tmp;
+	MATRIX_DATA(&buf, 1, 1) = tmp;
+	MATRIX_DATA(&buf, 2, 2) = tmp;
+
+	if (matrix_writeSubmatrix(out, 0, 1, &buf) < 0) {
+		return -1;
+	}
+
+	MATRIX_DATA(out, 0, 0) = q->a * v->x - vxq.x;
+	MATRIX_DATA(out, 1, 0) = q->a * v->y - vxq.y;
+	MATRIX_DATA(out, 2, 0) = q->a * v->z - vxq.z;
+
+	matrix_times(out, 2);
+
+	return 0;
+}
+
+
+int qvdiff_qvqDiffP(const quat_t *q, matrix_t *out)
+{
+	float qqtData[3 * 3] = { 0 }, tmp;
+	matrix_t qqt = { .data = qqtData, .rows = 3, .cols = 3, .transposed = 0 };
+	const vec_t qVec = { .x = q->i, .y = q->j, .z = q->k };
+
+	if (matrix_rowsGet(out) != 3 || matrix_colsGet(out) != 4 || out->transposed != 0) {
+		return -1;
+	}
+
+	qvdiff_crossMat(&qVec, out);
+	matrix_times(out, 2 * q->a);
+	/* Diagonal terms of `out` are now set to zeroes by `qvdiff_crossMat`. Proceed with diagonal terms */
+	tmp = q->a * q->a - (q->i * q->i + q->j * q->j + q->k * q->k);
+	MATRIX_DATA(out, 0, 0) = tmp;
+	MATRIX_DATA(out, 1, 1) = tmp;
+	MATRIX_DATA(out, 2, 2) = tmp;
+
+	MATRIX_DATA(&qqt, 0, 0) = q->i * q->i;
+	MATRIX_DATA(&qqt, 1, 1) = q->j * q->j;
+	MATRIX_DATA(&qqt, 2, 2) = q->k * q->k;
+
+	tmp = q->i * q->j;
+	MATRIX_DATA(&qqt, 0, 1) = tmp;
+	MATRIX_DATA(&qqt, 1, 0) = tmp;
+
+	tmp = q->i * q->k;
+	MATRIX_DATA(&qqt, 0, 2) = tmp;
+	MATRIX_DATA(&qqt, 2, 0) = tmp;
+
+	tmp = q->j * q->k;
+	MATRIX_DATA(&qqt, 1, 2) = tmp;
+	MATRIX_DATA(&qqt, 2, 1) = tmp;
+
+	matrix_times(&qqt, 2);
+	matrix_add(out, &qqt, NULL);
+
+	return 0;
+}
+
+
+int qvdiff_qpDiffQ(quat_t *p, matrix_t *out)
+{
+	if (matrix_rowsGet(out) != 4 || matrix_colsGet(out) != 4 || out->transposed != 0) {
+		return -1;
+	}
+
+	MATRIX_DATA(out, 0, 0) = p->a;
+	MATRIX_DATA(out, 1, 1) = p->a;
+	MATRIX_DATA(out, 2, 2) = p->a;
+	MATRIX_DATA(out, 3, 3) = p->a;
+
+	MATRIX_DATA(out, 0, 0) = p->i;
+	MATRIX_DATA(out, 2, 3) = p->i;
+	MATRIX_DATA(out, 0, 1) = -p->i;
+	MATRIX_DATA(out, 3, 2) = -p->i;
+
+	MATRIX_DATA(out, 2, 0) = p->j;
+	MATRIX_DATA(out, 3, 1) = p->j;
+	MATRIX_DATA(out, 0, 2) = -p->j;
+	MATRIX_DATA(out, 1, 3) = -p->j;
+
+	MATRIX_DATA(out, 1, 2) = p->k;
+	MATRIX_DATA(out, 3, 0) = p->k;
+	MATRIX_DATA(out, 0, 3) = -p->k;
+	MATRIX_DATA(out, 2, 1) = -p->k;
+
+	return 0;
+}
+
+
+int qvdiff_qpDiffP(const quat_t *q, matrix_t *out)
+{
+	if (matrix_rowsGet(out) != 4 || matrix_colsGet(out) != 3 || out->transposed != 0) {
+		return -1;
+	}
+
+	MATRIX_DATA(out, 1, 0) = q->a;
+	MATRIX_DATA(out, 2, 1) = q->a;
+	MATRIX_DATA(out, 3, 2) = q->a;
+
+	MATRIX_DATA(out, 3, 1) = q->i;
+	MATRIX_DATA(out, 0, 0) = -q->i;
+	MATRIX_DATA(out, 2, 2) = -q->i;
+
+	MATRIX_DATA(out, 1, 2) = q->j;
+	MATRIX_DATA(out, 0, 1) = -q->j;
+	MATRIX_DATA(out, 3, 0) = -q->j;
+
+	MATRIX_DATA(out, 2, 0) = q->k;
+	MATRIX_DATA(out, 0, 2) = -q->k;
+	MATRIX_DATA(out, 1, 1) = -q->j;
+
+	return 0;
+}


### PR DESCRIPTION
JIRA: PP-90

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Adding library `qdiff.h` that defines differentiation of:

 - $\huge(\partial qvq)/(\partial q )$
 - $\huge(\partial qvq)/(\partial v )$
 - $\huge(\partial qv)/(\partial q )$
 - $\huge(\partial qv)/(\partial v )$

$\huge q$ - quaternion
$\huge v$ - pure quaternion

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
 - These equations are currently implemented _in situ_ in `libekf`. As they are somewhat generic it is better to store them in `libalgeb`.
 - This change allows for writing tests to check the implementation of these and further optimalization 

These equations were inspired by this publication: [quaternion.pdf]( https://faculty.sites.iastate.edu/jia/files/inline-files/quaternion.pdf).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: zturn drone

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
