### PR TITLE
algebra: Levenberg–Marquardt algorithm implementation

### DIFF
--- a/algebra/Makefile
+++ b/algebra/Makefile
@@ -9,5 +9,5 @@
 #
 
 NAME := libalgeb
-LOCAL_SRCS := vec.c quat.c matrix.c qdiff.c
+LOCAL_SRCS := vec.c quat.c matrix.c qdiff.c lma.c
 include $(static-lib.mk)

--- a/algebra/include/lma.h
+++ b/algebra/include/lma.h
@@ -1,0 +1,110 @@
+/*
+ * Phoenix-Pilot
+ *
+ * lma - generic Levenberg–Marquardt algorithm implementation
+ *
+ * Copyright 2023 Phoenix Systems
+ * Author: Mateusz Niewiadomski
+ *
+ * This file is part of Phoenix-Pilot software
+ *
+ * %LICENSE%
+ */
+
+#ifndef PHOENIX_LIBALGEB_LMA_H
+#define PHOENIX_LIBALGEB_LMA_H
+
+#include <matrix.h>
+#include <stdbool.h>
+
+
+#define LMALOG_NONE          0
+#define LMALOG_DELTA         (1 << 0)
+#define LMALOG_PARAMS        (1 << 1)
+#define LMALOG_LAMBDA        (1 << 2)
+#define LMALOG_RESIDUUM      (1 << 3)
+#define LMALOG_USER_JACOBIAN (1 << 4)
+#define LMALOG_USER_RESIDUUM (1 << 5)
+
+
+/*
+* Function pointer to residuum jacobian solver for one sample point.
+* Calculates d(r(V,P))/d(P) in the point (V, P) where:
+* - r is a residuum function
+* - V is variables vector for current sample point
+* - P is parameters vector in current iteration
+* - J is output jacobian vector (set to zeroes by default)
+*
+* This function shall return -1 if calculation is not possible for given data which halts the LMA.
+* Otherwise returns 0;
+*/
+typedef int (*lmaJacobian)(const matrix_t *P, const matrix_t *V, matrix_t *J, bool log);
+
+/*
+* Function pointer to residuum solver.
+* Returns function residuum r = r(V, P) where:
+* - V is variables vector for current sample point
+* - P is parameters vector in current iteration
+*
+* This function shall return -1 if calculation is not possible for given data which halts the LMA.
+* Otherwise returns 0;
+*/
+typedef int (*lmaResiduum)(const matrix_t *P, const matrix_t *V, float *res, bool log);
+
+
+/*
+* Pointer to initial guess provider function.
+* This function shall fill parameters P vector with initial guess values
+*/
+typedef void (*lmaGuess)(matrix_t *P);
+
+
+typedef struct {
+	unsigned int nvars;    /* number of variables of funcition `f` */
+	unsigned int nparams;  /* number of parameters of function `f` */
+	unsigned int nsamples; /* size of the sample table */
+
+	matrix_t samples;
+	matrix_t jacobian;
+	matrix_t residua;
+	matrix_t residuaCandidate;
+	matrix_t delta;
+
+	/* user passed matrices */
+	matrix_t paramsVec;
+	matrix_t paramsCandVec;
+	matrix_t varsVec;
+	matrix_t jacobianVec;
+
+	/* helper matrices */
+	matrix_t helpPxP[2];
+	float *invBuf;
+	unsigned int invBufLen;
+
+	lmaJacobian solveJ;
+	lmaResiduum solveR;
+	lmaGuess guess;
+
+} fit_lma_t;
+
+
+/*
+* Performs fitting operation on `lma` with at most `maxSteps` LMA iterations.
+* Logs according to logFlags (multiple may be passed using bitewise OR).
+* On success returns number of iterations taken, on error returns -1.
+*/
+extern int lma_fit(unsigned int maxSteps, fit_lma_t *lma, unsigned int logFlags);
+
+
+/* Deinitializes all memory allocated by `lma` */
+extern int lma_done(fit_lma_t *lma);
+
+
+/*
+ * Initializes `lma` structure for fitting of function which has `nvars` variables and
+ * `nparams` parameters (fitted values). Fitting will be done for `n` samples.
+ * User must provide pointers to jacobian, residuum and initial guess solving functions.
+ * */
+extern int lma_init(unsigned int nvars, unsigned int nparams, unsigned int n, lmaJacobian solveJ, lmaResiduum solveR, lmaGuess guess, fit_lma_t *lma);
+
+#endif

--- a/algebra/include/matrix.h
+++ b/algebra/include/matrix.h
@@ -75,7 +75,7 @@ extern void matrix_trp(matrix_t *A);
 
 
 /* overwrites C with A * B */
-extern int matrix_prod(matrix_t *A, matrix_t *B, matrix_t *C);
+extern int matrix_prod(const matrix_t *A, const matrix_t *B, matrix_t *C);
 
 
 /* overwrites C with A * B, optimized for sparse A matrix */

--- a/algebra/lma.c
+++ b/algebra/lma.c
@@ -1,0 +1,314 @@
+/*
+ * Phoenix-Pilot
+ *
+ * lma - generic Levenberg–Marquardt algorithm implementation
+ *
+ * Copyright 2023 Phoenix Systems
+ * Author: Mateusz Niewiadomski
+ *
+ * This file is part of Phoenix-Pilot software
+ *
+ * %LICENSE%
+ */
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#include "lma.h"
+
+
+#define LMA_LAMBDA_START   1.f  /* Starting value of lambda parameter */
+#define LMA_LAMBDA_REWARD  0.1f /* Lambda parameter is ultiplied by it if better solution was found */
+#define LMA_LAMBDA_PENALTY 10.f /* Lambda parameter is ultiplied by it if worse solution was found */
+
+
+static void lma_log(unsigned int type, unsigned int flags, fit_lma_t *lma, unsigned int step, float lambda, float residuum)
+{
+	int currLog = type & flags;
+	int i;
+
+	if (currLog == LMALOG_NONE) {
+		return;
+	}
+
+	switch (currLog) {
+		case LMALOG_DELTA:
+			fprintf(stdout, "(%u)delta: (", step);
+			for (i = 0; i < lma->nparams; i++) {
+				fprintf(stdout, "%f ", MATRIX_DATA(&lma->delta, i, 0));
+			}
+			fprintf(stdout, ")\n");
+			break;
+
+		case LMALOG_PARAMS:
+			fprintf(stdout, "params: (");
+			for (i = 0; i < lma->nparams; i++) {
+				fprintf(stdout, "%f ", MATRIX_DATA(&lma->paramsVec, 0, i));
+			}
+			fprintf(stdout, ")\n");
+			break;
+
+		case LMALOG_LAMBDA:
+			fprintf(stdout, "lambda: %e\n", lambda);
+			break;
+
+		case LMALOG_RESIDUUM:
+			fprintf(stdout, "res: %e\n", residuum);
+			break;
+
+		default:
+			break;
+	}
+}
+
+
+/*
+* Solves the delta equation: lma->delta = inv(trp(J) * J + lambda * I) (trp(J) * R)
+*
+* This function manipulates sizes of matrices on its own to minimize the amount of initialized memory needed for calculations.
+* Invalidates contents of: lma->helpPxP[0], lma->helPxP[1], lma->helpPx1 and lma->invBuf.
+*/
+static int lma_solveDelta(float lambda, fit_lma_t *lma)
+{
+	/* This matrix shares memory with lma->jacobian but is transposed. Made it const so it isn`t changed by accident */
+	const matrix_t Jt = {
+		.data = lma->jacobian.data,
+		.transposed = 1,
+		.rows = lma->jacobian.rows,
+		.cols = lma->jacobian.cols
+	};
+
+	matrix_t localPx1;
+	int i;
+
+	/* Storing inverse of (J^t * J + lambda * I)^-1 into helpPxP[1] matrix */
+	matrix_prod(&Jt, &lma->jacobian, &lma->helpPxP[0]);
+	for (i = 0; i < lma->nparams; i++) {
+		MATRIX_DATA(&lma->helpPxP[0], i, i) += lambda;
+	}
+	matrix_inv(&lma->helpPxP[0], &lma->helpPxP[1], lma->invBuf, lma->invBufLen);
+
+	/* lma->helpPxP[0] is not used anymore. Aliasing it with localPx1 of smaller size */
+	localPx1 = lma->helpPxP[0];
+	localPx1.cols = 1;
+
+	matrix_prod(&Jt, &lma->residua, &localPx1);
+	matrix_prod(&lma->helpPxP[1], &localPx1, &lma->delta);
+
+	return 0;
+}
+
+
+/*
+* Writes full jacobian of residuals with respect to parameters into lma->jacobian matrix.
+* Invalidates contents of lma->varsVec and lma->jacovanVec.
+*/
+static int lma_solveJacobian(fit_lma_t *lma, bool log)
+{
+	unsigned int smpl, var;
+
+	for (smpl = 0; smpl < lma->nsamples; smpl++) {
+		/* Write current sample to varsVec */
+		for (var = 0; var < lma->nvars; var++) {
+			MATRIX_DATA(&lma->varsVec, 0, var) = MATRIX_DATA(&lma->samples, smpl, var);
+		}
+
+		/* Solve Jacobian row with current variables and parameters */
+		if (lma->solveJ(&lma->paramsVec, &lma->varsVec, &lma->jacobianVec, log) < 0) {
+			fprintf(stderr, "Error in jacobian solver\n");
+			return -1;
+		}
+
+		/* Write jacobian vector into full jacobian matrix */
+		matrix_writeSubmatrix(&lma->jacobian, smpl, 0, &lma->jacobianVec);
+	}
+
+	return 0;
+}
+
+
+/*
+* Writes full residua values into R matrix
+* Invalidates contents of lma->varsVec.
+*/
+static float lma_solveResidua(matrix_t *R, matrix_t *P, fit_lma_t *lma, float *out, bool log)
+{
+	unsigned int smpl, var;
+	double sum = 0; /* use double for sum to loose less accuracy on addition */
+	float res;
+
+	/* Calculate current redidua and sum of squares */
+	for (smpl = 0; smpl < lma->nsamples; smpl++) {
+		for (var = 0; var < lma->nvars; var++) {
+			MATRIX_DATA(&lma->varsVec, 0, var) = MATRIX_DATA(&lma->samples, smpl, var);
+		}
+
+		/* solve residuum problem for each sample and with current parameters */
+		if (lma->solveR(P, &lma->varsVec, &res, log) < 0) {
+			fprintf(stderr, "Error in residuum solver\n");
+			return -1;
+		}
+
+		/* Saving residuum as negative as later in `lma_solveDelta` it should be taken as negative */
+		MATRIX_DATA(R, smpl, 0) = -res; /* save current residuum */
+		sum += (double)res * res;       /* update sum of squares */
+	}
+
+	*out = sum;
+
+	return 0;
+}
+
+
+/*
+* LMA algorithm pseudocode:
+*
+* 1) P = initialGuess()
+* 2) (R,r) = sumOfRes(V, P)
+* 3) lambda = lambda0
+* 4) while !STOP:
+* 5)    J = solveJ(V, P)
+* 6)    delta = solveDelta(J, R, lambda)
+* 7)    P2 = P + lambda
+* 8)    (RTmp, rTmp) = sumOfRes(V, P2)
+* 9)    if (r2 < r):
+*            R = R2, P = P2, lambda /= 10
+*       else:
+*            lambda *= 10
+*/
+int lma_fit(unsigned int maxSteps, fit_lma_t *lma, unsigned int logFlags)
+{
+	const bool logUserResiduum = ((logFlags & LMALOG_USER_RESIDUUM) != LMALOG_NONE);
+	const bool logUserJacobian = ((logFlags & LMALOG_USER_JACOBIAN) != LMALOG_NONE);
+
+	float r, rCand;
+	float lambda;
+	unsigned int i;
+	matrix_t mTmp;
+
+	lma->guess(&lma->paramsVec); /* (1) */
+
+	/* (2) */
+	if (lma_solveResidua(&lma->residua, &lma->paramsVec, lma, &r, logUserResiduum) < 0) {
+		fprintf(stderr, "lma: residuum solver error\n");
+		return -1;
+	}
+
+	/* (3) */
+	lambda = LMA_LAMBDA_START;
+
+	/* (4) */
+	for (i = 0; i < maxSteps; i++) {
+		lma_log(LMALOG_PARAMS, logFlags, lma, i, lambda, r);
+		lma_log(LMALOG_DELTA, logFlags, lma, i, lambda, r);
+		lma_log(LMALOG_LAMBDA, logFlags, lma, i, lambda, r);
+		lma_log(LMALOG_RESIDUUM, logFlags, lma, i, lambda, r);
+
+		/* (5) */
+		if (lma_solveJacobian(lma, logUserJacobian) < 0) {
+			fprintf(stderr, "lma: jacobian solver error\n");
+			return -1;
+		}
+
+		/* (6) */
+		lma_solveDelta(lambda, lma);
+
+		/* (7) */
+		matrix_trp(&lma->delta);
+		matrix_add(&lma->paramsVec, &lma->delta, &lma->paramsCandVec);
+		matrix_trp(&lma->delta);
+
+		/* (8) */
+		if (lma_solveResidua(&lma->residuaCandidate, &lma->paramsCandVec, lma, &rCand, logUserResiduum) < 0) {
+			fprintf(stderr, "lma: residuum solver error\n");
+			return -1;
+		}
+
+		/* (9) */
+		if (rCand < r) {
+			mTmp = lma->residua;
+			lma->residua = lma->residuaCandidate;
+			lma->residuaCandidate = mTmp;
+
+			mTmp = lma->paramsVec;
+			lma->paramsVec = lma->paramsCandVec;
+			lma->paramsCandVec = mTmp;
+
+			lambda *= LMA_LAMBDA_REWARD;
+			r = rCand;
+		}
+		else {
+			lambda *= LMA_LAMBDA_PENALTY;
+		}
+	}
+
+	return i;
+}
+
+
+int lma_done(fit_lma_t *lma)
+{
+	matrix_bufFree(&lma->samples);
+	matrix_bufFree(&lma->jacobian);
+	matrix_bufFree(&lma->residua);
+	matrix_bufFree(&lma->residuaCandidate);
+	matrix_bufFree(&lma->delta);
+
+	matrix_bufFree(&lma->paramsVec);
+	matrix_bufFree(&lma->paramsCandVec);
+	matrix_bufFree(&lma->varsVec);
+	matrix_bufFree(&lma->jacobianVec);
+
+	matrix_bufFree(&lma->helpPxP[0]);
+	matrix_bufFree(&lma->helpPxP[1]);
+
+	free(lma->invBuf);
+	lma->invBuf = NULL;
+	lma->invBufLen = 0;
+
+	return 0;
+}
+
+
+int lma_init(unsigned int nvars, unsigned int nparams, unsigned int n, lmaJacobian solveJ, lmaResiduum solveR, lmaGuess guess, fit_lma_t *lma)
+{
+	/* Setting tmp to zeroes so unallocated pointers are NULL */
+	fit_lma_t tmp = { 0 };
+	int err = 0;
+
+	tmp.nvars = nvars;
+	tmp.nparams = nparams;
+	tmp.nsamples = n;
+
+	tmp.solveJ = solveJ;
+	tmp.solveR = solveR;
+	tmp.guess = guess;
+
+	err |= matrix_bufAlloc(&tmp.samples, tmp.nsamples, tmp.nvars);
+	err |= matrix_bufAlloc(&tmp.jacobian, tmp.nsamples, tmp.nparams);
+	err |= matrix_bufAlloc(&tmp.residua, tmp.nsamples, 1);
+	err |= matrix_bufAlloc(&tmp.residuaCandidate, tmp.nsamples, 1);
+	err |= matrix_bufAlloc(&tmp.delta, tmp.nparams, 1);
+
+	err |= matrix_bufAlloc(&tmp.paramsVec, 1, tmp.nparams);
+	err |= matrix_bufAlloc(&tmp.paramsCandVec, 1, tmp.nparams);
+	err |= matrix_bufAlloc(&tmp.varsVec, 1, tmp.nvars);
+	err |= matrix_bufAlloc(&tmp.jacobianVec, 1, tmp.nparams);
+
+	err |= matrix_bufAlloc(&tmp.helpPxP[0], tmp.nparams, tmp.nparams);
+	err |= matrix_bufAlloc(&tmp.helpPxP[1], tmp.nparams, tmp.nparams);
+
+	tmp.invBufLen = 2 * tmp.nparams * tmp.nparams;
+	tmp.invBuf = calloc(tmp.invBufLen, sizeof(float));
+
+	if (tmp.invBuf == NULL || err != 0) {
+		lma_done(&tmp);
+		return -1;
+	}
+
+	*lma = tmp;
+
+	return 0;
+}

--- a/algebra/matrix.c
+++ b/algebra/matrix.c
@@ -98,7 +98,7 @@ void matrix_trp(matrix_t *A)
 }
 
 
-int matrix_prod(matrix_t *A, matrix_t *B, matrix_t *C)
+int matrix_prod(const matrix_t *A, const matrix_t *B, matrix_t *C)
 {
 	unsigned int row, col;                               /* represent position in output C matrix */
 	unsigned int step;                                   /* represent stepping down over rows/columns in A and B */

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -24,3 +24,8 @@ NAME := rclog
 LOCAL_SRCS := rclog.c
 DEP_LIBS := librcbus
 include $(binary.mk)
+
+NAME := lmatest
+LOCAL_SRCS := lmatest.c
+DEP_LIBS := libalgeb
+include $(binary.mk)

--- a/utils/lmatest.c
+++ b/utils/lmatest.c
@@ -1,0 +1,92 @@
+/*
+ * Phoenix-Pilot
+ *
+ * lma.h usage example
+ *
+ * Function: x_1 = p_0 * sqrt( x_0 - p_1 * (x_0)^2 + p_2 * (x_0)^3 )
+ * Sample data generated for:
+ * p: (0.5, 0.5, 0.1)
+ * x1: in range [0.2, 4.0] with a step of 0.2
+ *
+ * Copyright 2023 Phoenix Systems
+ * Author: Mateusz Niewiadomski
+ *
+ * This file is part of Phoenix-Pilot software
+ *
+ * %LICENSE%
+ */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+
+#include <matrix.h>
+#include <lma.h>
+
+
+#define SAMPLES 20
+#define STEPS   16
+
+
+/* Sample data */
+const float tabX0[SAMPLES] = { 0.20, 0.40, 0.60, 0.80, 1.00, 1.20, 1.40, 1.60, 1.80, 2.00, 2.20, 2.40, 2.60, 2.80, 3.00, 3.20, 3.40, 3.60, 3.80, 4.00 };
+const float tabX1[SAMPLES] = { 0.21, 0.29, 0.33, 0.36, 0.39, 0.40, 0.42, 0.43, 0.44, 0.45, 0.46, 0.47, 0.49, 0.52, 0.55, 0.58, 0.62, 0.67, 0.72, 0.77 };
+
+
+int jacobian(const matrix_t *P, const matrix_t *V, matrix_t *J, bool log)
+{
+	float p[] = { MATRIX_DATA(P, 0, 0), MATRIX_DATA(P, 0, 1), MATRIX_DATA(P, 0, 2) };
+	float x = MATRIX_DATA(V, 0, 0);
+	float tmp;
+
+	tmp = sqrt(x * (-p[1] * x + p[2] * x * x + 1));
+
+	MATRIX_DATA(J, 0, 0) = sqrt(x - p[1] * x * x + p[2] * x * x * x);
+	MATRIX_DATA(J, 0, 1) = -0.5 * p[0] * x * x / tmp;
+	MATRIX_DATA(J, 0, 2) = 0.5 * p[0] * x * x * x / tmp;
+
+	return 0;
+}
+
+
+int residuum(const matrix_t *P, const matrix_t *V, float *res, bool log)
+{
+	float p[] = { MATRIX_DATA(P, 0, 0), MATRIX_DATA(P, 0, 1), MATRIX_DATA(P, 0, 2) };
+	float x[] = { MATRIX_DATA(V, 0, 0), MATRIX_DATA(V, 0, 1) };
+
+	*res = p[0] * sqrt(x[0] - p[1] * pow(x[0], 2) + p[2] * pow(x[0], 3)) - x[1];
+
+	return 0;
+}
+
+void guess(matrix_t *P)
+{
+	MATRIX_DATA(P, 0, 0) = 0;
+	MATRIX_DATA(P, 0, 1) = 0;
+	MATRIX_DATA(P, 0, 2) = 0;
+}
+
+
+int main(int argc, char **argv)
+{
+	fit_lma_t lma;
+	int i;
+
+	lma_init(2, 3, SAMPLES, jacobian, residuum, guess, &lma);
+
+	for (i = 0; i < SAMPLES; i++) {
+		MATRIX_DATA(&lma.samples, i, 0) = tabX0[i];
+		MATRIX_DATA(&lma.samples, i, 1) = tabX1[i];
+	}
+
+	lma_fit(STEPS, &lma, LMALOG_NONE);
+
+	printf(
+		"%f %f %f\n",
+		MATRIX_DATA(&lma.paramsVec, 0, 0),
+		MATRIX_DATA(&lma.paramsVec, 0, 1),
+		MATRIX_DATA(&lma.paramsVec, 0, 2));
+
+	lma_done(&lma);
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
 -  adding `lma.h`: generic Levenberg–Marquardt algorithm (LMA) implementation in libalgeb 
 - adding sample implementation of `lma.h` in _utils/_

LMA implementation follows mathematics described on wikipedia: https://en.wikipedia.org/wiki/Levenberg%E2%80%93Marquardt_algorithm

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: zturn drone, host-generic-pilot.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
