### PR TITLE
rcbus: radio loss coverage

### DIFF
--- a/libs/rcbus/rcbus.h
+++ b/libs/rcbus/rcbus.h
@@ -22,13 +22,21 @@
 typedef enum { rc_typeIbus = 0, rc_typeSbus } rcbus_type_t;
 
 
+typedef enum {
+	rc_err_ok = 0,  /* no error */
+	rc_err_silence, /* radio is silent, signal lost */
+	rc_err_readerr, /* device read error */
+	rc_err_gibber   /* malformed data */
+} rcbus_err_t;
+
+
 typedef struct {
 	size_t channelsCnt;
 	uint16_t *channels;
 } rcbus_msg_t;
 
 
-typedef void (*RcMsgHandler)(const rcbus_msg_t *msg);
+typedef void (*RcMsgHandler)(const rcbus_msg_t *msg, rcbus_err_t err);
 
 
 /* New thread for reading data is launched. If the correct packet is received, the handler is invoked.

--- a/utils/rclog.c
+++ b/utils/rclog.c
@@ -9,16 +9,22 @@
 
 
 struct {
-	bool run;
+	volatile bool run;
 } rclog_common;
 
 
-static void rclog_rcbusHandler(const rcbus_msg_t *msg)
+static void rclog_rcbusHandler(const rcbus_msg_t *msg, rcbus_err_t err)
 {
 	const static uint16_t maxTriggerVal = MIN_CHANNEL_VALUE + ((95 * (MAX_CHANNEL_VALUE - MIN_CHANNEL_VALUE)) / 100);
 
 	int i;
 	time_t now;
+
+	if (err != rc_err_ok) {
+		fprintf(stderr, "rclog: signal lost; error %d\n", err);
+		rclog_common.run = 0;
+		return;
+	}
 
 	if (msg->channelsCnt < RC_CHANNELS_CNT) {
 		fprintf(stderr, "rclog: rcbus supports insufficient number of channels\n");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Loosing signal from radio receiver, loosing the receiver at all (disconnect) or system error on reading the receiver port now signal this in the form of error variable.

All current uses of `rcbus` got implemented with this error handling. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Recent fly-away incident with drone shed a light on lack of failsafe feature in an event of receiver power-down.

Although the signal loss is not covered by this change, an event of receiver loosing supply voltage is covered as it will halt data transmission.

Loosing signal must be handled in the transmitter itself which may trigger some action on receiver if signal is lost as (for our fs-i6-x transmitter) is covered here:
 - https://www.flysky-cn.com/journal/2021/2/21/about-the-flysky-remote-control-failsafe-function

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: zturn drone

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
