### PR TITLE
rcbus: initialize error in positive error state

### DIFF
--- a/libs/rcbus/rcbus.c
+++ b/libs/rcbus/rcbus.c
@@ -169,6 +169,7 @@ static void rcbus_rcvThread(void *arg)
 		tv.tv_sec = rcbus_common.timeout / 1000;
 		tv.tv_usec = (rcbus_common.timeout % 1000) * 1000;
 
+		rcerr = rc_err_gibber;
 		err = select(rcbus_common.fd + 1, &rfds, NULL, NULL, &tv);
 		if (err > 0) {
 			res = read(rcbus_common.fd, data, sz);


### PR DESCRIPTION
- current state produces an error of undefined variable

JIRA: PP-138

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Removing compilation warning of possible undefined variable state in `rcbus`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
