### PR TITLE
algebra: fix `matrix_sandwitch` functions

### DIFF
--- a/algebra/include/matrix.h
+++ b/algebra/include/matrix.h
@@ -82,7 +82,7 @@ extern int matrix_prod(const matrix_t *A, const matrix_t *B, matrix_t *C);
 extern int matrix_sparseProd(const matrix_t *A, const matrix_t *B, matrix_t *C);
 
 
-/* overwrites C with A * B * transposed(A), optimized for sparse A */
+/* overwrites C with A * B * transposed(A) */
 extern int matrix_sandwitch(const matrix_t *A, const matrix_t *B, matrix_t *C, matrix_t *tempC);
 
 

--- a/algebra/matrix.c
+++ b/algebra/matrix.c
@@ -292,7 +292,7 @@ static inline int matrix_sandwitchValid(const matrix_t *A, const matrix_t *B, co
 
 int matrix_sparseSandwitch(const matrix_t *A, const matrix_t *B, matrix_t *C, matrix_t *tempC)
 {
-	const matrix_t trpA = { .data = A->data, .rows = A->rows, .cols = A->cols, .transposed = 1 };
+	const matrix_t trpA = { .data = A->data, .rows = A->rows, .cols = A->cols, .transposed = !A->transposed };
 
 	if (!matrix_sandwitchValid(A, B, C, tempC)) {
 		return -1;
@@ -306,7 +306,7 @@ int matrix_sparseSandwitch(const matrix_t *A, const matrix_t *B, matrix_t *C, ma
 
 int matrix_sandwitch(const matrix_t *A, const matrix_t *B, matrix_t *C, matrix_t *tempC)
 {
-	const matrix_t trpA = { .data = A->data, .rows = A->rows, .cols = A->cols, .transposed = 1 };
+	const matrix_t trpA = { .data = A->data, .rows = A->rows, .cols = A->cols, .transposed = !A->transposed };
 
 	if (!matrix_sandwitchValid(A, B, C, tempC)) {
 		return -1;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
This PR fixes bug with calculating sandwich operation, when the first matrix from arguments is transposed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug fix

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here). `host-generic-pilot` `armv7a9-zynq7000-qemu`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
