### PR TITLE
quad-control: changes in modes handling

### DIFF
--- a/quadcontrol/control.c
+++ b/quadcontrol/control.c
@@ -631,6 +631,18 @@ static int quad_run(void)
 }
 
 
+static inline bool quad_rcChLow(int32_t ch)
+{
+	return (ch <= RC_CHANNEL_THR_LOW);
+}
+
+
+static inline bool quad_rcChHgh(int32_t ch)
+{
+	return (ch >= RC_CHANNEL_THR_HIGH);
+}
+
+
 static void quad_rcbusHandler(const rcbus_msg_t *msg, rcbus_err_t err)
 {
 	/* abort frame counting variable*/
@@ -656,21 +668,18 @@ static void quad_rcbusHandler(const rcbus_msg_t *msg, rcbus_err_t err)
 	}
 
 	/* Manual Disarm: SWA == MIN, SWB == MIN, SWC == MIN, SWD == MIN, Throttle == 0 && mode_rc */
-	if (msg->channels[RC_SWA_CH] <= RC_CHANNEL_THR_LOW && msg->channels[RC_SWB_CH] <= RC_CHANNEL_THR_LOW
-			&& msg->channels[RC_SWC_CH] <= RC_CHANNEL_THR_LOW && msg->channels[RC_SWD_CH] <= RC_CHANNEL_THR_LOW
-			&& msg->channels[RC_LEFT_VSTICK_CH] <= RC_CHANNEL_THR_LOW && quad_common.currFlight == flight_idle) {
+	if (quad_rcChLow(msg->channels[RC_SWA_CH]) && quad_rcChLow(msg->channels[RC_SWB_CH]) && quad_rcChLow(msg->channels[RC_SWC_CH]) && quad_rcChLow(msg->channels[RC_SWD_CH])
+			&& quad_rcChLow(msg->channels[RC_LEFT_VSTICK_CH]) && quad_common.currFlight == flight_idle) {
 		printf("rc: set f_disarm\n");
 		quad_common.currFlight = flight_disarm;
 	}
 	/* Manual Arm: SWA == MAX, SWB == MIN and Throttle == 0 and scenario cannot be launched */
-	else if (msg->channels[RC_SWA_CH] >= RC_CHANNEL_THR_HIGH && msg->channels[RC_LEFT_VSTICK_CH] <= RC_CHANNEL_THR_LOW
-			&& quad_common.currFlight == flight_disarm) {
+	else if (quad_rcChHgh(msg->channels[RC_SWA_CH]) && quad_rcChLow(msg->channels[RC_LEFT_VSTICK_CH]) && quad_common.currFlight == flight_disarm) {
 		printf("rc: set f_arm\n");
 		quad_common.currFlight = flight_arm;
 	}
 	/* Emergency abort: SWA == MAX, SWB == MAX, SWC == MAX, SWD == MAX */
-	else if (msg->channels[RC_SWA_CH] >= RC_CHANNEL_THR_HIGH && msg->channels[RC_SWB_CH] >= RC_CHANNEL_THR_HIGH
-			&& msg->channels[RC_SWC_CH] >= RC_CHANNEL_THR_HIGH && msg->channels[RC_SWD_CH] >= RC_CHANNEL_THR_HIGH 
+	else if (quad_rcChHgh(msg->channels[RC_SWA_CH]) && quad_rcChHgh(msg->channels[RC_SWB_CH]) && quad_rcChHgh(msg->channels[RC_SWC_CH]) && quad_rcChHgh(msg->channels[RC_SWD_CH])
 			&& quad_common.currFlight < flight_manualAbort) {
 		abortCnt++;
 		printf("rc: f_abort called %i\n", abortCnt);
@@ -683,7 +692,7 @@ static void quad_rcbusHandler(const rcbus_msg_t *msg, rcbus_err_t err)
 		return;
 	}
 	/* Manual Mode: SWA == MAX, SWB == MAX */
-	else if (msg->channels[RC_SWA_CH] >= RC_CHANNEL_THR_HIGH && msg->channels[RC_SWB_CH] >= RC_CHANNEL_THR_HIGH && quad_common.currFlight < flight_manual) {
+	else if (quad_rcChHgh(msg->channels[RC_SWA_CH]) && quad_rcChHgh(msg->channels[RC_SWB_CH]) && quad_common.currFlight < flight_manual) {
 		printf("rc: set f_manual\n");
 		quad_common.currFlight = flight_manual;
 	}

--- a/quadcontrol/control.c
+++ b/quadcontrol/control.c
@@ -214,6 +214,18 @@ static void quad_rcOverride(quad_att_t *att, float *throttle, uint32_t flags)
 }
 
 
+static inline bool quad_rcChLow(int32_t ch)
+{
+	return (ch <= RC_CHANNEL_THR_LOW);
+}
+
+
+static inline bool quad_rcChHgh(int32_t ch)
+{
+	return (ch >= RC_CHANNEL_THR_HIGH);
+}
+
+
 /* Handling flight modes */
 
 static int quad_takeoff(const flight_mode_t *mode)
@@ -629,18 +641,6 @@ static int quad_run(void)
 	}
 
 	return err;
-}
-
-
-static inline bool quad_rcChLow(int32_t ch)
-{
-	return (ch <= RC_CHANNEL_THR_LOW);
-}
-
-
-static inline bool quad_rcChHgh(int32_t ch)
-{
-	return (ch >= RC_CHANNEL_THR_HIGH);
 }
 
 

--- a/quadcontrol/control.c
+++ b/quadcontrol/control.c
@@ -789,9 +789,8 @@ static void quad_rcbusHandler(const rcbus_msg_t *msg, rcbus_err_t err)
 		return;
 	}
 
-	/* Emergency abort: SWA == MAX, SWB == MAX, SWC == MAX, SWD == MAX */
-	if (quad_rcChHgh(msg->channels[RC_SWA_CH]) && quad_rcChHgh(msg->channels[RC_SWB_CH]) && quad_rcChHgh(msg->channels[RC_SWC_CH]) && quad_rcChHgh(msg->channels[RC_SWD_CH])
-			&& quad_common.currFlight < flight_manualAbort) {
+	/* Emergency abort: SWD == MAX, throttle = MIN */
+	if (quad_rcChHgh(msg->channels[RC_SWD_CH]) && quad_rcChLow(msg->channels[RC_LEFT_VSTICK_CH]) && quad_common.currFlight < flight_manualAbort) {
 		abortCnt++;
 		printf("rc: f_abort called %i\n", abortCnt);
 
@@ -802,8 +801,8 @@ static void quad_rcbusHandler(const rcbus_msg_t *msg, rcbus_err_t err)
 
 		return;
 	}
-	/* Manual Mode: SWA == MAX, SWB == MAX */
-	else if (quad_rcChHgh(msg->channels[RC_SWA_CH]) && quad_rcChHgh(msg->channels[RC_SWB_CH]) && quad_common.currFlight < flight_manual) {
+	/* Manual Mode: SWA == MIN */
+	else if (quad_rcChLow(msg->channels[RC_SWA_CH]) && quad_common.currFlight > flight_arm && quad_common.currFlight < flight_manual) {
 		printf("rc: set f_manual\n");
 		quad_common.currFlight = flight_manual;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
 - **manual abort procedure is simplified to SWD = HIGH and throttle down**
 - radio receiver disconnect error is now time based as it was too verbose and polluted logs
 - changed modes handling so that the least possible checks are done in radio handler, the rest is done in mode-specific routines
 - routines for `quad_idle/disarm/arm` are just like typical flight modes routines and handle the RC signals and proceed forward or backwards.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Radio handler should only handle priority modes like abort and enforcing manual mode in case of drone misbehaving.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
