### PR TITLE
Change behaviour of `algebraTests_buffFill`

### DIFF
--- a/algebra/tests/matrix/add_sub.c
+++ b/algebra/tests/matrix/add_sub.c
@@ -58,7 +58,7 @@ TEST_SETUP(group_matrix_add_stdMat)
 
 	/* Allocating matrix for results and filling with non zero data */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M3, Expected.rows, Expected.cols));
-	algebraTests_buffFill(&M3, initVal, initValLen);
+	TEST_ASSERT_EQUAL_INT(MAT_BUFFILL_OK, algebraTests_buffFill(&M3, initVal, BUFFILL_WRITE_ALL));
 }
 
 
@@ -240,7 +240,7 @@ TEST_SETUP(group_matrix_add_bigMat)
 
 	/* Allocating matrix for results and filling with non zero data */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M3, Expected.rows, Expected.cols));
-	algebraTests_buffFill(&M3, initVal, initValLen);
+	TEST_ASSERT_EQUAL_INT(MAT_BUFFILL_OK, algebraTests_buffFill(&M3, initVal, BUFFILL_WRITE_ALL));
 
 	M4.data = NULL;
 	M5.data = NULL;
@@ -619,7 +619,7 @@ TEST_SETUP(group_matrix_sub_stdMat)
 
 	/* Allocating matrix for results and filling with non zero data */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M3, Expected.rows, Expected.cols));
-	algebraTests_buffFill(&M3, initVal, initValLen);
+	TEST_ASSERT_EQUAL_INT(MAT_BUFFILL_OK, algebraTests_buffFill(&M3, initVal, BUFFILL_WRITE_ALL));
 }
 
 
@@ -801,7 +801,7 @@ TEST_SETUP(group_matrix_sub_bigMat)
 
 	/* Allocating matrix for results and filling with non zero data */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M3, Expected.rows, Expected.cols));
-	algebraTests_buffFill(&M3, initVal, initValLen);
+	TEST_ASSERT_EQUAL_INT(MAT_BUFFILL_OK, algebraTests_buffFill(&M3, initVal, BUFFILL_WRITE_ALL));
 
 	M4.data = NULL;
 	M5.data = NULL;

--- a/algebra/tests/matrix/buffs.h
+++ b/algebra/tests/matrix/buffs.h
@@ -18,7 +18,6 @@
 
 /* Value for initiating matrices. Must be different than zero and one. */
 static const float initVal[] = {4.5f};
-static const int initValLen = 1;
 
 /* A - small square matrix with integer values */
 static const unsigned int buffs_rowsA = 3, buffs_colsA = 3;

--- a/algebra/tests/matrix/inverse.c
+++ b/algebra/tests/matrix/inverse.c
@@ -50,7 +50,7 @@ TEST_SETUP(group_matrix_inv_stdMat)
 
 	/* Allocating matrix for results and filling with non zero data */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M2, Expected.rows, Expected.cols));
-	algebraTests_buffFill(&M2, initVal, initValLen);
+	TEST_ASSERT_EQUAL_INT(MAT_BUFFILL_OK, algebraTests_buffFill(&M2, initVal, BUFFILL_WRITE_ALL));
 
 	bufLen = M1.rows * M1.cols * 2;
 	buf = malloc(sizeof(float) * bufLen);
@@ -152,7 +152,7 @@ TEST_SETUP(group_matrix_inv_bigMat)
 
 	/* Allocating matrix for results and filling with non zero data */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M2, M1.rows, M1.cols));
-	algebraTests_buffFill(&M2, initVal, initValLen);
+	TEST_ASSERT_EQUAL_INT(MAT_BUFFILL_OK, algebraTests_buffFill(&M2, initVal, BUFFILL_WRITE_ALL));
 
 	/* Allocating temporary matrix */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M3, M1.rows, M1.cols));
@@ -272,7 +272,7 @@ TEST(group_matrix_inv_otherMats, matrix_inv_zeroOnDiag)
 
 	/* Allocating matrix for results and filling with non zero data */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M2, Expected.rows, Expected.cols));
-	algebraTests_buffFill(&M2, initVal, initValLen);
+	TEST_ASSERT_EQUAL_INT(MAT_BUFFILL_OK, algebraTests_buffFill(&M2, initVal, BUFFILL_WRITE_ALL));
 
 	bufLen = M1.rows * M1.cols * 2;
 	buf = malloc(sizeof(float) * bufLen);
@@ -304,7 +304,7 @@ TEST_SETUP(group_matrix_inv_badMat)
 
 	/* Allocating matrix for results and filling with non zero data */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M2, M1.rows, M1.cols));
-	algebraTests_buffFill(&M2, initVal, initValLen);
+	TEST_ASSERT_EQUAL_INT(MAT_BUFFILL_OK, algebraTests_buffFill(&M2, initVal, BUFFILL_WRITE_ALL));
 
 	bufLen = M1.rows * M1.cols * 2;
 	buf = malloc(sizeof(float) * bufLen);

--- a/algebra/tests/matrix/mulitiplication.c
+++ b/algebra/tests/matrix/mulitiplication.c
@@ -50,7 +50,7 @@ TEST_SETUP(group_matrix_prod_stdMat)
 
 	/* Allocating matrix for results and filling with non zero data */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M3, Expected.rows, Expected.cols));
-	algebraTests_buffFill(&M3, initVal, initValLen);
+	TEST_ASSERT_EQUAL_INT(MAT_BUFFILL_OK, algebraTests_buffFill(&M3, initVal, BUFFILL_WRITE_ALL));
 }
 
 
@@ -166,7 +166,7 @@ TEST_SETUP(group_matrix_prod_bigMat)
 
 	/* Allocating matrix for results and filling with non zero data */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M3, Expected.rows, Expected.cols));
-	algebraTests_buffFill(&M3, initVal, initValLen);
+	TEST_ASSERT_EQUAL_INT(MAT_BUFFILL_OK, algebraTests_buffFill(&M3, initVal, BUFFILL_WRITE_ALL));
 
 	M4.data = NULL;
 	M5.data = NULL;
@@ -420,7 +420,7 @@ TEST_SETUP(group_matrix_sparseProd_stdMat)
 
 	/* Allocating matrix for results and filling with non zero data */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M3, Expected.rows, Expected.cols));
-	algebraTests_buffFill(&M3, initVal, initValLen);
+	TEST_ASSERT_EQUAL_INT(MAT_BUFFILL_OK, algebraTests_buffFill(&M3, initVal, BUFFILL_WRITE_ALL));
 }
 
 
@@ -536,7 +536,7 @@ TEST_SETUP(group_matrix_sparseProd_bigMat)
 
 	/* Allocating matrix for results and filling with non zero data */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M3, Expected.rows, Expected.cols));
-	algebraTests_buffFill(&M3, initVal, initValLen);
+	TEST_ASSERT_EQUAL_INT(MAT_BUFFILL_OK, algebraTests_buffFill(&M3, initVal, BUFFILL_WRITE_ALL));
 
 	M4.data = NULL;
 	M5.data = NULL;

--- a/algebra/tests/matrix/sandwitch.c
+++ b/algebra/tests/matrix/sandwitch.c
@@ -52,7 +52,7 @@ TEST_SETUP(group_matrix_sandwitch_stdMat)
 
 	/* Allocating matrix for results and filling with non zero data */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M3, Expected.rows, Expected.cols));
-	algebraTests_buffFill(&M3, initVal, initValLen);
+	TEST_ASSERT_EQUAL_INT(MAT_BUFFILL_OK, algebraTests_buffFill(&M3, initVal, BUFFILL_WRITE_ALL));
 
 	/* Allocating temporary matrix */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&tmp, M1.rows, M2.cols));
@@ -172,7 +172,7 @@ TEST_SETUP(group_matrix_sandwitch_bigMat)
 
 	/* Allocating matrix for results and filling with non zero data */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M3, Expected.rows, Expected.cols));
-	algebraTests_buffFill(&M3, initVal, initValLen);
+	TEST_ASSERT_EQUAL_INT(MAT_BUFFILL_OK, algebraTests_buffFill(&M3, initVal, BUFFILL_WRITE_ALL));
 
 	/* Allocating temporary matrix */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&tmp, M1.rows, M2.cols));
@@ -460,7 +460,7 @@ TEST_SETUP(group_matrix_sparseSandwitch_stdMat)
 
 	/* Allocating matrix for results and filling with non zero data */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M3, Expected.rows, Expected.cols));
-	algebraTests_buffFill(&M3, initVal, initValLen);
+	TEST_ASSERT_EQUAL_INT(MAT_BUFFILL_OK, algebraTests_buffFill(&M3, initVal, BUFFILL_WRITE_ALL));
 
 	/* Allocating temporary matrix */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&tmp, M1.rows, M2.cols));
@@ -579,7 +579,7 @@ TEST_SETUP(group_matrix_sparseSandwitch_bigMat)
 
 	/* Allocating matrix for results and filling with non zero data */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M3, Expected.rows, Expected.cols));
-	algebraTests_buffFill(&M3, initVal, initValLen);
+	TEST_ASSERT_EQUAL_INT(MAT_BUFFILL_OK, algebraTests_buffFill(&M3, initVal, BUFFILL_WRITE_ALL));
 
 	/* Allocating temporary matrix */
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&tmp, M1.rows, M2.cols));

--- a/algebra/tests/matrix/various.c
+++ b/algebra/tests/matrix/various.c
@@ -100,7 +100,7 @@ TEST_TEAR_DOWN(group_matrix_zeroes)
 TEST(group_matrix_zeroes, matrix_zeroes_std)
 {
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M1, ROWS, COLS));
-	algebraTests_buffFill(&M1, initVal, initValLen);
+	TEST_ASSERT_EQUAL_INT(MAT_BUFFILL_OK, algebraTests_buffFill(&M1, initVal, BUFFILL_WRITE_ALL));
 
 	matrix_zeroes(&M1);
 
@@ -115,7 +115,7 @@ TEST(group_matrix_zeroes, matrix_zeroes_std)
 TEST(group_matrix_zeroes, matrix_zeroes_stdTrp)
 {
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M1, ROWS, COLS));
-	algebraTests_buffFill(&M1, initVal, initValLen);
+	TEST_ASSERT_EQUAL_INT(MAT_BUFFILL_OK, algebraTests_buffFill(&M1, initVal, BUFFILL_WRITE_ALL));
 	matrix_trp(&M1);
 
 	matrix_zeroes(&M1);
@@ -173,7 +173,7 @@ TEST_TEAR_DOWN(group_matrix_diag)
 TEST(group_matrix_diag, matrix_diag_squareMat)
 {
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M1, SQUARE_MAT_SIZE, SQUARE_MAT_SIZE));
-	algebraTests_buffFill(&M1, initVal, initValLen);
+	TEST_ASSERT_EQUAL_INT(MAT_BUFFILL_OK, algebraTests_buffFill(&M1, initVal, BUFFILL_WRITE_ALL));
 
 	matrix_diag(&M1);
 
@@ -185,7 +185,7 @@ TEST(group_matrix_diag, matrix_diag_squareMatTrp)
 {
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M1, SQUARE_MAT_SIZE, SQUARE_MAT_SIZE));
 	matrix_trp(&M1);
-	algebraTests_buffFill(&M1, initVal, initValLen);
+	TEST_ASSERT_EQUAL_INT(MAT_BUFFILL_OK, algebraTests_buffFill(&M1, initVal, BUFFILL_WRITE_ALL));
 
 	matrix_diag(&M1);
 
@@ -196,7 +196,7 @@ TEST(group_matrix_diag, matrix_diag_squareMatTrp)
 TEST(group_matrix_diag, matrix_diag_notSquareMat)
 {
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M1, ROWS, COLS));
-	algebraTests_buffFill(&M1, initVal, initValLen);
+	TEST_ASSERT_EQUAL_INT(MAT_BUFFILL_OK, algebraTests_buffFill(&M1, initVal, BUFFILL_WRITE_ALL));
 
 	matrix_diag(&M1);
 
@@ -208,7 +208,7 @@ TEST(group_matrix_diag, matrix_diag_notSquareMatTrp)
 {
 	TEST_ASSERT_EQUAL_INT(MAT_BUF_ALLOC_OK, matrix_bufAlloc(&M1, ROWS, COLS));
 	matrix_trp(&M1);
-	algebraTests_buffFill(&M1, initVal, initValLen);
+	TEST_ASSERT_EQUAL_INT(MAT_BUFFILL_OK, algebraTests_buffFill(&M1, initVal, BUFFILL_WRITE_ALL));
 
 	matrix_diag(&M1);
 

--- a/algebra/tests/tools.c
+++ b/algebra/tests/tools.c
@@ -27,7 +27,7 @@ void test_assert_float_array_within(float delta, float *expected, float *actual,
 }
 
 
-void algebraTests_buffFill(matrix_t *M, const float *vals, unsigned int n)
+int algebraTests_buffFill(matrix_t *M, const float *vals, int n)
 {
 	int rowsNum, colsNum, row, col;
 	int i = 0;
@@ -35,11 +35,17 @@ void algebraTests_buffFill(matrix_t *M, const float *vals, unsigned int n)
 	rowsNum = matrix_rowsGet(M);
 	colsNum = matrix_colsGet(M);
 
+	if (n != rowsNum * colsNum && n != BUFFILL_WRITE_ALL) {
+		return -1;
+	}
+
 	for (row = 0; row < rowsNum; row++) {
 		for (col = 0; col < colsNum; col++) {
-			*matrix_at(M, row, col) = (n > 1) ? vals[i++] : vals[i];
+			*matrix_at(M, row, col) = (n == BUFFILL_WRITE_ALL) ? vals[i] : vals[i++];
 		}
 	}
+
+	return 0;
 }
 
 
@@ -49,8 +55,7 @@ int algebraTests_createAndFill(matrix_t *M, unsigned int rows, unsigned int cols
 		return MAT_BUF_ALLOC_FAIL;
 	}
 
-	algebraTests_buffFill(M, vals, n);
-	return MAT_BUF_ALLOC_OK;
+	return algebraTests_buffFill(M, vals, n);
 }
 
 

--- a/algebra/tests/tools.h
+++ b/algebra/tests/tools.h
@@ -68,6 +68,12 @@
 /* Define for `vec_cmp` results */
 #define QUAT_CMP_OK 0
 
+/* ----------------        defines used in tools functions       ---------------- */
+
+#define BUFFILL_WRITE_ALL -1
+
+#define MAT_BUFFILL_OK 0
+
 /* ------------------------        general defines       ------------------------ */
 
 /* Defines for functions that validate object parameters */
@@ -139,11 +145,11 @@ extern void test_assert_float_array_within(float delta, float *expected, float *
  * ############################################################################## */
 
 
-/* Fill matrix buffer with n-length array vals. If n=1 whole matrix is filled with vals[0] */
-extern void algebraTests_buffFill(matrix_t *M, const float *vals, unsigned int n);
+/* Fill matrix buffer with n-length array vals. If n=BUFFILL_WRITE_ALL whole matrix is filled with vals[0] */
+extern int algebraTests_buffFill(matrix_t *M, const float *vals, int n);
 
 
-/* Create and fill matrix with n-length array vals. If n=1 whole matrix is filled with vals[0]. M must be uninitialized */
+/* Create and fill matrix with n-length array vals. M must be uninitialized */
 extern int algebraTests_createAndFill(matrix_t *M, unsigned int rows, unsigned int cols, const float *vals, unsigned int n);
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
This PR changes the behavior of `algebraTests_buffFiff`. Now this function fills whole matrix with single value when `BUFFILL_WRITE_ALL` is passed as an argument. In previous version this took plane when the length of passed table was equal to 1.

Moreover now this function return an information about potential errors.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Better looking interface

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here). `host-generic-pc` `armv7a9-zynq7000-qemu`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
