### PR TITLE
Change `qpDiffQ` tests: use statically allocated matrix in test

### DIFF
--- a/algebra/tests/qdiff/tests.c
+++ b/algebra/tests/qdiff/tests.c
@@ -120,17 +120,18 @@ TEST(group_qvdiff_qpDiffQ, qvdiff_qpDiffQ_resTrp)
 
 TEST(group_qvdiff_qpDiffQ, qvdiff_qpDiffQ_wrongOutputMatrixSize)
 {
-	matrix_bufFree(&M);
+	float buff[(ROWS_QUAT_DIFF + 1) * (COLS_QUAT_DIFF + 1)];
+	matrix_t mat = { .data = buff, .transposed = 0 };
 
 	/* Too small matrix */
-	matrix_bufAlloc(&M, ROWS_QUAT_DIFF - 1, COLS_QUAT_DIFF - 1);
-	TEST_ASSERT_NOT_EQUAL(0, qvdiff_qpDiffQ(&A, &M));
-
-	matrix_bufFree(&M);
+	mat.rows = ROWS_QUAT_DIFF - 1;
+	mat.cols = COLS_QUAT_DIFF - 1;
+	TEST_ASSERT_NOT_EQUAL(0, qvdiff_qpDiffQ(&A, &mat));
 
 	/* Too big matrix */
-	matrix_bufAlloc(&M, ROWS_QUAT_DIFF + 1, COLS_QUAT_DIFF + 1);
-	TEST_ASSERT_NOT_EQUAL(0, qvdiff_qpDiffQ(&A, &M));
+	mat.rows = ROWS_QUAT_DIFF + 1;
+	mat.cols = COLS_QUAT_DIFF + 1;
+	TEST_ASSERT_NOT_EQUAL(0, qvdiff_qpDiffQ(&A, &mat));
 }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Changes test with wrong output matrix size. Now it uses statically allocated matrix same as `qpDiffV` tests.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
More consistent testing methods.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here). `armv7a9-zynq7000-qemu`, `host-generic-pc`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
