### PR TITLE
lma: fix `lma_solveResidua` return type

### DIFF
--- a/algebra/lma.c
+++ b/algebra/lma.c
@@ -133,7 +133,7 @@ static int lma_solveJacobian(fit_lma_t *lma, bool log)
 * Writes full residua values into R matrix
 * Invalidates contents of lma->varsVec.
 */
-static float lma_solveResidua(matrix_t *R, matrix_t *P, fit_lma_t *lma, float *out, bool log)
+static int lma_solveResidua(matrix_t *R, matrix_t *P, fit_lma_t *lma, float *out, bool log)
 {
 	unsigned int smpl, var;
 	double sum = 0; /* use double for sum to loose less accuracy on addition */


### PR DESCRIPTION
JIRA: PP-141

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
`lma_solveResidua` has wrong return type of float, should be int.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
 - https://github.com/phoenix-pilot/phoenix-pilot-core/issues/207

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
