### PR TITLE
calib: axis swapping in `accorth`

### DIFF
--- a/libs/calib/calib.c
+++ b/libs/calib/calib.c
@@ -255,7 +255,8 @@ static int calib_magironRead(FILE *file, calib_data_t *cal)
 static int calib_accorthEnter(const char *paramName, calib_data_t *cal, float val)
 {
 	matrix_t *mat = NULL;
-	unsigned int row, col;
+	unsigned int row, col, axis;
+	char swapVal;
 	float *slot;
 
 	if (strlen(paramName) != 3) {
@@ -264,6 +265,9 @@ static int calib_accorthEnter(const char *paramName, calib_data_t *cal, float va
 
 	row = (uint8_t)(paramName[1] - '0'); /* convert character to unsigned int digit */
 	col = (uint8_t)(paramName[2] - '0'); /* convert character to unsigned int digit */
+
+	swapVal = paramName[1];
+	axis = (uint8_t)(paramName[2] - '0'); /* convert character to unsigned int digit */
 
 	/* matrix type get through character check */
 	switch (paramName[0]) {
@@ -299,6 +303,25 @@ static int calib_accorthEnter(const char *paramName, calib_data_t *cal, float va
 				case 3:
 					cal->params.accorth.frameQ.k = val;
 					break;
+				default:
+					return -1;
+			}
+			return 0;
+
+		case ACC_CHAR_SWAP:
+			switch (swapVal) {
+				case ACC_CHAR_SWAP_ORDR:
+					cal->params.accorth.swapOrder = val;
+					break;
+
+				case ACC_CHAR_SWAP_SIGN:
+					if ((val != 0 && val != 1) || axis > 2 || axis < 0) {
+						fprintf(stderr, "accorth invalid swap sign\n");
+						return -1;
+					}
+					cal->params.accorth.axisInv[axis] = val;
+					break;
+
 				default:
 					return -1;
 			}
@@ -348,6 +371,12 @@ static inline void calib_accorthDefaults(calib_data_t *cal)
 	cal->params.accorth.frameQ.i = 0;
 	cal->params.accorth.frameQ.j = 0;
 	cal->params.accorth.frameQ.k = 0;
+
+	/* By default no swapping is performed */
+	cal->params.accorth.axisInv[0] = 0;
+	cal->params.accorth.axisInv[1] = 0;
+	cal->params.accorth.axisInv[2] = 0;
+	cal->params.accorth.swapOrder = 123;
 }
 
 

--- a/libs/calib/calib.h
+++ b/libs/calib/calib.h
@@ -69,7 +69,7 @@ typedef struct {
 			matrix_t ortho;      /* 3x3 nonorthogonality parameters matrix */
 			matrix_t offset;     /* 3x1 measurement offset matrix */
 			quat_t frameQ;       /* initial rotation quaternion of accelerometer in relation to body frame */
-			accSwap_t swapOrder; /* axis swap order: e.g 312 means that [x,y,z] will be read as [z, x, y] */
+			accSwap_t swapOrder; /* axis swap order; according to `accSwap_t` enum */
 			int axisInv[3];      /* x,y,z axis inversion flags. 1 means that axis should be inverted after swapping is performed */
 		} accorth;
 

--- a/libs/calib/calib.h
+++ b/libs/calib/calib.h
@@ -34,10 +34,13 @@
 #define HARDCAL_COLSPAN 1
 
 #define ACCORTH_TAG        "accorth"
-#define ACCORTH_PARAMS     16
+#define ACCORTH_PARAMS     20
 #define ACC_CHAR_ORTHO     'o'
 #define ACC_CHAR_OFFSET    'h'
 #define ACC_CHAR_QUAT      'q'
+#define ACC_CHAR_SWAP      's'
+#define ACC_CHAR_SWAP_SIGN 's'
+#define ACC_CHAR_SWAP_ORDR 'o'
 #define ACC_ORTHO_ROWSPAN  3
 #define ACC_ORTHO_COLSPAN  3
 #define ACC_OFFSET_ROWSPAN 3
@@ -47,9 +50,12 @@
 #define MOTLIN_TAG    "motlin"
 #define MOTLIN_PARAMS 8
 
-
+/* clang-format off */
 typedef enum { typeMagmot = 0, typeMagiron, typeMotlin, typeAccorth } calibType_t;
 
+
+typedef enum { accSwapXYZ = 0, accSwapXZY, accSwapYXZ, accSwapYZX, accSwapZXY, accSwapZYX } accSwap_t;
+/* clang-format on */
 
 typedef struct {
 	calibType_t type;
@@ -60,9 +66,11 @@ typedef struct {
 		} magiron;
 
 		struct {
-			matrix_t ortho;  /* 3x3 nonorthogonality parameters matrix */
-			matrix_t offset; /* 3x1 measurement offset matrix */
-			quat_t frameQ;   /* initial rotation quaternion of accelerometer in relation to body frame */
+			matrix_t ortho;      /* 3x3 nonorthogonality parameters matrix */
+			matrix_t offset;     /* 3x1 measurement offset matrix */
+			quat_t frameQ;       /* initial rotation quaternion of accelerometer in relation to body frame */
+			accSwap_t swapOrder; /* axis swap order: e.g 312 means that [x,y,z] will be read as [z, x, y] */
+			int axisInv[3];      /* x,y,z axis inversion flags. 1 means that axis should be inverted after swapping is performed */
 		} accorth;
 
 		struct {

--- a/libs/sensc/corr.c
+++ b/libs/sensc/corr.c
@@ -225,11 +225,58 @@ void corr_mag(sensor_event_t *magEvt)
 }
 
 
+void corr_accrotVecSwap(vec_t *v)
+{
+	switch (corr_common.accorth.params.accorth.swapOrder) {
+		case accSwapXZY:
+			*v = (vec_t) { .x = v->x, .y = v->z, .z = v->y };
+			break;
+
+		case accSwapYXZ:
+			*v = (vec_t) { .x = v->y, .y = v->x, .z = v->z };
+			break;
+
+		case accSwapYZX:
+			*v = (vec_t) { .x = v->y, .y = v->z, .z = v->x };
+			break;
+
+		case accSwapZXY:
+			*v = (vec_t) { .x = v->z, .y = v->x, .z = v->y };
+			break;
+
+		case accSwapZYX:
+			*v = (vec_t) { .x = v->z, .y = v->y, .z = v->x };
+			break;
+
+		case accSwapXYZ:
+		default:
+			/* no swap */
+			break;
+	}
+
+	if (corr_common.accorth.params.accorth.axisInv[0] == 1) {
+		v->x = -v->x;
+	}
+
+	if (corr_common.accorth.params.accorth.axisInv[1] == 1) {
+		v->y = -v->y;
+	}
+
+	if (corr_common.accorth.params.accorth.axisInv[2] == 1) {
+		v->z = -v->z;
+	}
+}
+
+
 void corr_accrot(sensor_event_t *accelEvt, sensor_event_t *gyroEvt, sensor_event_t *magEvt)
 {
 	vec_t accel = { .x = accelEvt->accels.accelX, .y = accelEvt->accels.accelY, .z = accelEvt->accels.accelZ };
 	vec_t gyro = { .x = gyroEvt->gyro.gyroX, .y = gyroEvt->gyro.gyroY, .z = gyroEvt->gyro.gyroZ };
 	vec_t mag = { .x = magEvt->mag.magX, .y = magEvt->mag.magY, .z = magEvt->mag.magZ };
+
+	corr_accrotVecSwap(&accel);
+	corr_accrotVecSwap(&gyro);
+	corr_accrotVecSwap(&mag);
 
 	quat_vecRot(&accel, &corr_common.accorth.params.accorth.frameQ);
 	quat_vecRot(&gyro, &corr_common.accorth.params.accorth.frameQ);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Addition of axis swapping/inversion solution in IMU initial rotation estimation. From now on measurements of IMU are not only rotated using quaternion but also their order is switched and inverted if necessary. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Estimating IMU rotation only with quaternion has a room for an error if that rotation is big/complex (not along one axis). Instead of using only quaternion it may be easier to firstly switch axis order and/or invert some of them and then calculate the quaternion. 

This way big rotations are not included in the quaternion so it more correctly estimates the missalignment of the axis. This also makes the calibration procedure more robust i.e. differences between consecutive calibration procedures in calibtool are smaller

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: zturn drone.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
