### PR TITLE
pilot-core: imu temperature and gyrorth calibration + gps double usage

### DIFF
--- a/calib/Makefile
+++ b/calib/Makefile
@@ -8,7 +8,7 @@
 
 # Magnetometer calibration tool
 NAME := calibtool
-CALIBS := magmot.c magiron.c motesc.c motlin.c accorth.c tempimu.c
+CALIBS := magmot.c magiron.c motesc.c motlin.c accorth.c tempimu.c gyrorth.c
 LOCAL_SRCS := main.c ellcal.c linlsm.c $(CALIBS)
 DEP_LIBS := libsensc libmctl libalgeb libcalib libhmap
 LIBS := libzynq7000pwm

--- a/calib/Makefile
+++ b/calib/Makefile
@@ -9,7 +9,7 @@
 # Magnetometer calibration tool
 NAME := calibtool
 CALIBS := magmot.c magiron.c motesc.c motlin.c accorth.c tempimu.c
-LOCAL_SRCS := main.c ellcal.c $(CALIBS)
+LOCAL_SRCS := main.c ellcal.c linlsm.c $(CALIBS)
 DEP_LIBS := libsensc libmctl libalgeb libcalib libhmap
 LIBS := libzynq7000pwm
 include $(binary.mk)

--- a/calib/Makefile
+++ b/calib/Makefile
@@ -8,7 +8,7 @@
 
 # Magnetometer calibration tool
 NAME := calibtool
-CALIBS := magmot.c magiron.c motesc.c motlin.c accorth.c
+CALIBS := magmot.c magiron.c motesc.c motlin.c accorth.c tempimu.c
 LOCAL_SRCS := main.c ellcal.c $(CALIBS)
 DEP_LIBS := libsensc libmctl libalgeb libcalib libhmap
 LIBS := libzynq7000pwm

--- a/calib/accorth.c
+++ b/calib/accorth.c
@@ -607,7 +607,7 @@ static int accorth_done(void)
 
 static int accorth_init(int argc, const char **argv)
 {
-	if (sensc_init(SENSOR_PATH, CORR_ENBL_NONE, SENSC_INIT_IMU) < 0) {
+	if (sensc_init(SENSOR_PATH, ACCORTH_CALIB_DEPENDENCY, SENSC_INIT_IMU) < 0) {
 		return -1;
 	}
 

--- a/calib/accorth.c
+++ b/calib/accorth.c
@@ -607,7 +607,7 @@ static int accorth_done(void)
 
 static int accorth_init(int argc, const char **argv)
 {
-	if (sensc_init(SENSOR_PATH, false, SENSC_INIT_IMU) < 0) {
+	if (sensc_init(SENSOR_PATH, CORR_ENBL_NONE, SENSC_INIT_IMU) < 0) {
 		return -1;
 	}
 

--- a/calib/gyrorth.c
+++ b/calib/gyrorth.c
@@ -1,0 +1,96 @@
+/*
+ * Phoenix-Pilot
+ *
+ * Drone motors linear compensation procedure
+ * Calibration of inequalities between engines PWMs that level the drone
+ *
+ * Copyright 2022 Phoenix Systems
+ * Author: Mateusz Niewiadomski
+ *
+ * This file is part of Phoenix-Pilot software
+ *
+ * %LICENSE%
+ */
+
+#include <stdio.h>
+#include <errno.h>
+
+#include <matrix.h>
+
+#include "calibtool.h"
+
+struct {
+	calib_data_t data;
+} gyrorth_common;
+
+
+/* Returns pointer to internal parameters for read purposes */
+static calib_data_t *gyrorth_dataGet(void)
+{
+	return &gyrorth_common.data;
+}
+
+
+static const char *gyrorth_help(void)
+{
+	return "Gyroscope nonorthogonality calibration\n";
+}
+
+
+static int gyrorth_write(FILE *file)
+{
+	unsigned int row, col;
+
+	for (row = 0; row < ACC_OFFSET_ROWSPAN; row++) {
+		for (col = 0; col < ACC_OFFSET_COLSPAN; col++) {
+			fprintf(file, "%c%u%u %f\n", ACC_CHAR_OFFSET, row, col, MATRIX_DATA(&gyrorth_common.data.params.gyrorth.offset, row, col));
+		}
+	}
+
+	for (row = 0; row < ACC_ORTHO_ROWSPAN; row++) {
+		for (col = 0; col < ACC_ORTHO_COLSPAN; col++) {
+			fprintf(file, "%c%u%u %f\n", ACC_CHAR_ORTHO, row, col, MATRIX_DATA(&gyrorth_common.data.params.gyrorth.ortho, row, col));
+		}
+	}
+	return EOK;
+}
+
+
+static int gyrorth_done(void)
+{
+	return EOK;
+}
+
+
+int gyrorth_run(void)
+{
+	printf("This calibration is not yet implemented!\n");
+	printf("This calibration returns default parameters if there are none in calibration file\n");
+	printf("Calibration done!\n");
+
+	return EOK;
+}
+
+
+static int gyrorth_init(int argc, const char **argv)
+{
+	return EOK;
+}
+
+
+__attribute__((constructor(102))) static void gyrorth_register(void)
+{
+	static calib_ops_t cal = {
+		.name = GYRORTH_TAG,
+		.init = gyrorth_init,
+		.run = gyrorth_run,
+		.done = gyrorth_done,
+		.write = gyrorth_write,
+		.help = gyrorth_help,
+		.dataGet = gyrorth_dataGet
+	};
+
+	calib_register(&cal);
+
+	gyrorth_common.data.type = typeGyrorth;
+}

--- a/calib/linlsm.c
+++ b/calib/linlsm.c
@@ -1,0 +1,61 @@
+/*
+ * Phoenix-Pilot
+ *
+ * Linear Least Squares method implementation
+ *
+ * Copyright 2023 Phoenix Systems
+ * Author: Mateusz Niewiadomski
+ *
+ * This file is part of Phoenix-Pilot software
+ *
+ * %LICENSE%
+ */
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "linlsm.h"
+
+/* produces least square linear fitting to data collected so far. Outputs coefficients and delta */
+void linlsm_get(linlsm_t *lsm, float *a, float *b, float *delta)
+{
+	float deltaLocal, aLocal, bLocal;
+
+	deltaLocal = lsm->n * lsm->sxx - (lsm->sx * lsm->sx);
+	aLocal = (float)(lsm->n * lsm->sxy - lsm->sx * lsm->sy) / deltaLocal;
+	bLocal = (float)(lsm->sxx * lsm->sy - lsm->sx * lsm->sxy) / deltaLocal;
+
+	if (a != NULL) {
+		*a = aLocal;
+	}
+
+	if (b != NULL) {
+		*b = bLocal;
+	}
+
+	if (delta != NULL) {
+		*delta = deltaLocal;
+	}
+}
+
+
+/* updates linear least square method structure with new data point (x, y) */
+void linlsm_update(linlsm_t *lsm, float x, float y)
+{
+	lsm->n++;
+	lsm->sx += x;
+	lsm->sy += y;
+	lsm->sxx += x * x;
+	lsm->sxy += x * y;
+}
+
+
+/* initializes linear least square method structure (no alloc) */
+void linlsm_init(linlsm_t *lsm)
+{
+	lsm->n = 0;
+	lsm->sx = 0;
+	lsm->sy = 0;
+	lsm->sxx = 0;
+	lsm->sxy = 0;
+}

--- a/calib/linlsm.h
+++ b/calib/linlsm.h
@@ -1,0 +1,36 @@
+/*
+ * Phoenix-Pilot
+ *
+ * Linear Least Squares method implementation
+ *
+ * Copyright 2023 Phoenix Systems
+ * Author: Mateusz Niewiadomski
+ *
+ * This file is part of Phoenix-Pilot software
+ *
+ * %LICENSE%
+ */
+
+#ifndef CALIBTOOL_LINLSM_H_
+#define CALIBTOOL_LINLSM_H_
+
+#include <stdint.h>
+
+typedef struct {
+	int64_t n;
+	double sx;
+	double sy;
+	double sxx;
+	double sxy;
+} linlsm_t;
+
+/* produces least square linear fitting to data collected so far. Outputs coefficients and delta */
+void linlsm_get(linlsm_t *lsm, float *a, float *b, float *delta);
+
+/* updates linear least square method structure with new data point (x, y) */
+void linlsm_update(linlsm_t *lsm, float x, float y);
+
+/* initializes linear least square method structure (no alloc) */
+void linlsm_init(linlsm_t *lsm);
+
+#endif

--- a/calib/magiron.c
+++ b/calib/magiron.c
@@ -215,7 +215,7 @@ static int magiron_run(void)
 
 static int magiron_init(int argc, const char **argv)
 {
-	if (sensc_init(SENSOR_PATH, false, SENSC_INIT_IMU) < 0) {
+	if (sensc_init(SENSOR_PATH, CORR_ENBL_NONE, SENSC_INIT_IMU) < 0) {
 		return -1;
 	}
 

--- a/calib/magiron.c
+++ b/calib/magiron.c
@@ -215,7 +215,7 @@ static int magiron_run(void)
 
 static int magiron_init(int argc, const char **argv)
 {
-	if (sensc_init(SENSOR_PATH, CORR_ENBL_NONE, SENSC_INIT_IMU) < 0) {
+	if (sensc_init(SENSOR_PATH, MAGIRON_CALIB_DEPENDENCY, SENSC_INIT_IMU) < 0) {
 		return -1;
 	}
 

--- a/calib/magmot.c
+++ b/calib/magmot.c
@@ -256,7 +256,7 @@ static int magmot_done(void)
 
 static int magmot_init(int argc, const char **argv)
 {
-	if (sensc_init(SENSOR_PATH, CORR_ENBL_NONE, SENSC_INIT_IMU) < 0) {
+	if (sensc_init(SENSOR_PATH, MAGMOT_CALIB_DEPENDENCY, SENSC_INIT_IMU) < 0) {
 		return -ENXIO;
 	}
 

--- a/calib/magmot.c
+++ b/calib/magmot.c
@@ -256,7 +256,7 @@ static int magmot_done(void)
 
 static int magmot_init(int argc, const char **argv)
 {
-	if (sensc_init(SENSOR_PATH, false, SENSC_INIT_IMU) < 0) {
+	if (sensc_init(SENSOR_PATH, CORR_ENBL_NONE, SENSC_INIT_IMU) < 0) {
 		return -ENXIO;
 	}
 

--- a/calib/main.c
+++ b/calib/main.c
@@ -86,7 +86,7 @@ static int calib_read(const char *path)
 	while (c != NULL) {
 		if (c->dataGet != NULL) {
 			calib = c->dataGet();
-			if (calib_readFile(path, calib->type, calib) != 0) {
+			if (calib_dataInit(path, calib->type, calib) != 0) {
 				err = true;
 				break;
 			}

--- a/calib/tempimu.c
+++ b/calib/tempimu.c
@@ -1,10 +1,9 @@
 /*
  * Phoenix-Pilot
  *
- * Drone motors linear compensation procedure
- * Calibration of inequalities between engines PWMs that level the drone
+ * IMU temperature compensation
  *
- * Copyright 2022 Phoenix Systems
+ * Copyright 2023 Phoenix Systems
  * Author: Mateusz Niewiadomski
  *
  * This file is part of Phoenix-Pilot software
@@ -14,12 +13,73 @@
 
 #include <stdio.h>
 #include <errno.h>
+#include <unistd.h>
+#include <string.h>
+#include <math.h>
+
+#include <sensc.h>
+#include <vec.h>
+#include <statistics.h>
+#include <libsensors.h>
 
 #include "calibtool.h"
+#include "linlsm.h"
+
+
+#define DATA_POINTS                  600   /* How many data points linear fittting uses */
+#define DATA_POINT_SAMPLES           100   /* How many times each data point is sampled */
+#define DATA_POINT_SAMPLES_PERIOD_US 10000 /* Sampling perion [us] during data point averaging */
+
+#define MIN_TEMP_DIFF 3
 
 struct {
 	calib_data_t data;
 } tempimu_common;
+
+
+/* Averages accel reading over `samples` samples with `usDelay` period. Returns 0 on success */
+static int tempimu_imuAvg(unsigned int samples, time_t usDelay, sensor_event_t *accOut, sensor_event_t *gyrOut)
+{
+	sensor_event_t accelEvt, gyrEvt, magEvt;
+	int64_t acc[3], gyr[3], tempAcc, tempGyr;
+	int i;
+
+	memset(acc, 0, sizeof(int64_t) * 3);
+	memset(gyr, 0, sizeof(int64_t) * 3);
+	tempAcc = 0;
+	tempGyr = 0;
+
+	for (i = 0; i < samples; i++) {
+		if (sensc_imuGet(&accelEvt, &gyrEvt, &magEvt) != 0) {
+			fprintf(stderr, "%s: imuGet fail\n", TEMPIMU_TAG);
+			return -1;
+		}
+
+		acc[0] += accelEvt.accels.accelX;
+		acc[1] += accelEvt.accels.accelY;
+		acc[2] += accelEvt.accels.accelZ;
+		tempAcc += accelEvt.accels.temp;
+
+		gyr[0] += gyrEvt.gyro.gyroX;
+		gyr[1] += gyrEvt.gyro.gyroY;
+		gyr[2] += gyrEvt.gyro.gyroZ;
+		tempGyr += gyrEvt.gyro.temp;
+
+		usleep(usDelay);
+	}
+
+	accOut->accels.accelX = (float)acc[0] / samples;
+	accOut->accels.accelY = (float)acc[1] / samples;
+	accOut->accels.accelZ = (float)acc[2] / samples;
+	accOut->accels.temp = (float)tempAcc / samples;
+
+	gyrOut->gyro.gyroX = (float)gyr[0] / samples;
+	gyrOut->gyro.gyroY = (float)gyr[1] / samples;
+	gyrOut->gyro.gyroZ = (float)gyr[2] / samples;
+	gyrOut->gyro.temp = (float)tempGyr / samples;
+
+	return 0;
+}
 
 
 /* Returns pointer to internal parameters for read purposes */
@@ -58,14 +118,75 @@ static int tempimu_write(FILE *file)
 
 static int tempimu_done(void)
 {
+	sensc_deinit();
+
 	return EOK;
 }
 
 
 int tempimu_run(void)
 {
-	printf("This calibration returns default parameters if there are none in calibration file\n");
-	printf("Calibration done!");
+	calib_data_t *calib = &tempimu_common.data;
+	sensor_event_t accelEvt, gyrEvt;
+	linlsm_t lsmAcc[3];
+	linlsm_t lsmGyr[3];
+	float refTempStart, refTempEnd;
+	int i;
+
+	for (i = 0; i < 3; i++) {
+		linlsm_init(&lsmAcc[i]);
+		linlsm_init(&lsmGyr[i]);
+	}
+
+	/* Averaging start/end temperature 2x more than usual samples */
+	if (tempimu_imuAvg(DATA_POINT_SAMPLES * 2, DATA_POINT_SAMPLES_PERIOD_US, &accelEvt, &gyrEvt) != 0) {
+		fprintf(stderr, "%s: failed to average temp\n", TEMPIMU_TAG);
+		return -1;
+	}
+	refTempStart = (float)accelEvt.accels.temp / 1000; /* from millikelvins to kelvins */
+
+	fprintf(stdout, "Reference temperature is %.1f K\n", refTempStart);
+	fprintf(stdout, "Keep drone still for 10 minutes. Collecting data...\n");
+
+	for (i = 0; i < DATA_POINTS; i++) {
+		/*  */
+		if (tempimu_imuAvg(DATA_POINT_SAMPLES, DATA_POINT_SAMPLES_PERIOD_US, &accelEvt, &gyrEvt) < 0) {
+			fprintf(stderr, "%s: imuGet fail\n", TEMPIMU_TAG);
+			return -1;
+		}
+
+		linlsm_update(&lsmAcc[0], (float)accelEvt.accels.temp / 1000, accelEvt.accels.accelX);
+		linlsm_update(&lsmAcc[1], (float)accelEvt.accels.temp / 1000, accelEvt.accels.accelY);
+		linlsm_update(&lsmAcc[2], (float)accelEvt.accels.temp / 1000, accelEvt.accels.accelZ);
+
+		linlsm_update(&lsmGyr[0], (float)gyrEvt.gyro.temp / 1000, gyrEvt.gyro.gyroX);
+		linlsm_update(&lsmGyr[1], (float)gyrEvt.gyro.temp / 1000, gyrEvt.gyro.gyroY);
+		linlsm_update(&lsmGyr[2], (float)gyrEvt.gyro.temp / 1000, gyrEvt.gyro.gyroZ);
+	}
+
+	/* Averaging start/end temperature 2x more than usual samples */
+	if (tempimu_imuAvg(DATA_POINT_SAMPLES_PERIOD_US * 2, DATA_POINT_SAMPLES_PERIOD_US, &accelEvt, &gyrEvt) != 0) {
+		fprintf(stderr, "%s: failed to average temp\n", TEMPIMU_TAG);
+		return -1;
+	}
+	refTempEnd = (float)accelEvt.accels.temp / 1000; /* from millikelvins to kelvins */
+
+	if (fabs(refTempEnd - refTempStart) < MIN_TEMP_DIFF) {
+		fprintf(stderr, "%s: insufficient temperature difference from %d to %d. Must be at least %d\n", TEMPIMU_TAG, (int)refTempStart, (int)refTempEnd, MIN_TEMP_DIFF);
+		return -1;
+	}
+
+	/* Calibration finished, checking parmateres integrity. Average temperature will be used as refTemp */
+	for (i = 0; i < 3; i++) {
+		linlsm_get(&lsmAcc[i], &calib->params.tempimu.alfaAcc[i], NULL, NULL);
+		linlsm_get(&lsmGyr[i], &calib->params.tempimu.alfaGyr[i], NULL, NULL);
+	}
+	calib->params.tempimu.refTemp = (refTempStart + refTempEnd) / 2;
+
+	printf("%s params:\n", TEMPIMU_TAG);
+	printf("acc: %f %f %f\n", calib->params.tempimu.alfaAcc[0], calib->params.tempimu.alfaAcc[1], calib->params.tempimu.alfaAcc[2]);
+	printf("gyr: %f %f %f\n", calib->params.tempimu.alfaGyr[0], calib->params.tempimu.alfaGyr[1], calib->params.tempimu.alfaGyr[2]);
+	printf("reftemp: %.1f\n", calib->params.tempimu.refTemp);
 
 	return EOK;
 }
@@ -73,6 +194,10 @@ int tempimu_run(void)
 
 static int tempimu_init(int argc, const char **argv)
 {
+	if (sensc_init(SENSOR_PATH, TEMPIMU_CALIB_DEPENDENCY, SENSC_INIT_IMU) < 0) {
+		return -1;
+	}
+
 	return EOK;
 }
 

--- a/calib/tempimu.c
+++ b/calib/tempimu.c
@@ -1,0 +1,95 @@
+/*
+ * Phoenix-Pilot
+ *
+ * Drone motors linear compensation procedure
+ * Calibration of inequalities between engines PWMs that level the drone
+ *
+ * Copyright 2022 Phoenix Systems
+ * Author: Mateusz Niewiadomski
+ *
+ * This file is part of Phoenix-Pilot software
+ *
+ * %LICENSE%
+ */
+
+#include <stdio.h>
+#include <errno.h>
+
+#include "calibtool.h"
+
+struct {
+	calib_data_t data;
+} tempimu_common;
+
+
+/* Returns pointer to internal parameters for read purposes */
+static calib_data_t *tempimu_dataGet(void)
+{
+	return &tempimu_common.data;
+}
+
+
+static const char *tempimu_help(void)
+{
+	return "Temperature-IMU calibration\n";
+}
+
+
+static int tempimu_write(FILE *file)
+{
+	int axis;
+
+	/* reference temperature write */
+	fprintf(file, "rt %f\n", tempimu_common.data.params.tempimu.refTemp);
+
+	/* accelerometer coefficients */
+	for (axis = 0; axis < 3; axis++) {
+		fprintf(file, "a%d %f\n", axis, tempimu_common.data.params.tempimu.alfaAcc[axis]);
+	}
+
+	/* gyro coefficients */
+	for (axis = 0; axis < 3; axis++) {
+		fprintf(file, "g%d %f\n", axis, tempimu_common.data.params.tempimu.alfaGyr[axis]);
+	}
+
+	return EOK;
+}
+
+
+static int tempimu_done(void)
+{
+	return EOK;
+}
+
+
+int tempimu_run(void)
+{
+	printf("This calibration returns default parameters if there are none in calibration file\n");
+	printf("Calibration done!");
+
+	return EOK;
+}
+
+
+static int tempimu_init(int argc, const char **argv)
+{
+	return EOK;
+}
+
+
+__attribute__((constructor(102))) static void tempimu_register(void)
+{
+	static calib_ops_t cal = {
+		.name = TEMPIMU_TAG,
+		.init = tempimu_init,
+		.run = tempimu_run,
+		.done = tempimu_done,
+		.write = tempimu_write,
+		.help = tempimu_help,
+		.dataGet = tempimu_dataGet
+	};
+
+	calib_register(&cal);
+
+	tempimu_common.data.type = typeTempimu;
+}

--- a/ekf/meas.c
+++ b/ekf/meas.c
@@ -98,7 +98,7 @@ int meas_init(meas_sourceType_t sourceType, const char *path, int senscInitFlags
 			meas_common.timeAcq = sensc_timeGet;
 			meas_common.baroAcq = sensc_baroGet;
 
-			return sensc_init(path, true, senscInitFlags);
+			return sensc_init(path, CORR_ENBL_ALL, senscInitFlags);
 
 		case srcLog:
 			meas_common.imuAcq = ekflog_imuRead;

--- a/ekf/meas.h
+++ b/ekf/meas.h
@@ -56,7 +56,7 @@ typedef struct {
 	} baro;
 
 	struct {
-		vec_t refEcef;               /* reference point ECEF coordinates */
+		double refEcef[3];           /* reference point ECEF coordinates */
 		meas_geodetic_t refGeodetic; /* reference point geodetic coordinates */
 	} gps;
 } meas_calib_t;

--- a/libs/calib/calib.c
+++ b/libs/calib/calib.c
@@ -658,7 +658,7 @@ void calib_free(calib_data_t *cal)
 }
 
 
-int calib_readFile(const char *path, calibType_t type, calib_data_t *cal)
+int calib_dataInit(const char *path, calibType_t type, calib_data_t *cal)
 {
 	FILE *file;
 	int ret;

--- a/libs/calib/calib.h
+++ b/libs/calib/calib.h
@@ -106,7 +106,7 @@ typedef struct {
 * Read calibration file pointed by 'path' searching for calibration named `tag` and saving its content to 'cal'.
 * If 'path' does not point to a file default values are written and 0 is returned (success).
 */
-int calib_readFile(const char *path, calibType_t type, calib_data_t *cal);
+int calib_dataInit(const char *path, calibType_t type, calib_data_t *cal);
 
 
 /* Deallocates all memory used by 'cal' */

--- a/libs/calib/calib.h
+++ b/libs/calib/calib.h
@@ -62,6 +62,12 @@
 #define TEMPIMU_SANE_GYR_ALFA 10  /* maximum absolute value of gyroscope temperature coef. [(mrad / s) / K] */
 
 
+/* CORRECTIONS DEPENDENCY CONTROL */
+#define TEMPIMU_CALIB_DEPENDENCY (CORR_ENBL_NONE)
+#define MAGIRON_CALIB_DEPENDENCY (CORR_ENBL_TEMPIMU)
+#define ACCORTH_CALIB_DEPENDENCY (CORR_ENBL_TEMPIMU)
+#define MAGMOT_CALIB_DEPENDENCY  (CORR_ENBL_TEMPIMU | CORR_ENBL_MAGIRON)
+
 /* clang-format off */
 typedef enum { typeMagmot = 0, typeMagiron, typeMotlin, typeAccorth, typeTempimu } calibType_t;
 

--- a/libs/calib/calib.h
+++ b/libs/calib/calib.h
@@ -50,8 +50,20 @@
 #define MOTLIN_TAG    "motlin"
 #define MOTLIN_PARAMS 8
 
+
+#define TEMPIMU_TAG           "tempimu"
+#define TEMPIMU_PARAMS        7
+#define TEMPIMU_CHAR_REF      'r'
+#define TEMPIMU_CHAR_ACC      'a'
+#define TEMPIMU_CHAR_GYR      'g'
+#define TEMPIMU_SANE_MAXREF   400 /* max refTemp value accepted */
+#define TEMPIMU_SANE_MINREF   200 /* min refTemp value accepted*/
+#define TEMPIMU_SANE_ACC_ALFA 100 /* maximum absolute value of accelerometer temperature coef. [(mm / s^2) / K] */
+#define TEMPIMU_SANE_GYR_ALFA 10  /* maximum absolute value of gyroscope temperature coef. [(mrad / s) / K] */
+
+
 /* clang-format off */
-typedef enum { typeMagmot = 0, typeMagiron, typeMotlin, typeAccorth } calibType_t;
+typedef enum { typeMagmot = 0, typeMagiron, typeMotlin, typeAccorth, typeTempimu } calibType_t;
 
 
 typedef enum { accSwapXYZ = 0, accSwapXZY, accSwapYXZ, accSwapYZX, accSwapZXY, accSwapZYX } accSwap_t;
@@ -80,6 +92,12 @@ typedef struct {
 		struct {
 			float motorEq[NUM_OF_MOTORS][2]; /* motorEq[motorId 0/1/2...NUM_OF_MOTORS][equation_parameter a/b] */
 		} motlin;
+
+		struct {
+			float refTemp;    /* reference temperatutre in kelvins (K) */
+			float alfaAcc[3]; /* linear coefficients [(mm / s^2) / K] for temperature compensation for x/y/z accelerometer axis */
+			float alfaGyr[3]; /* linear coefficients [(mrad / s) / K] for temperature compensation for x/y/z gyroscope axis */
+		} tempimu;
 	} params;
 } calib_data_t;
 

--- a/libs/calib/calib.h
+++ b/libs/calib/calib.h
@@ -62,14 +62,25 @@
 #define TEMPIMU_SANE_GYR_ALFA 10  /* maximum absolute value of gyroscope temperature coef. [(mrad / s) / K] */
 
 
+#define GYRORTH_TAG            "gyrorth"
+#define GYRORTH_PARAMS         12
+#define GYRORTH_CHAR_ORTHO     'o'
+#define GYRORTH_CHAR_OFFSET    'h'
+#define GYRORTH_ORTHO_ROWSPAN  3
+#define GYRORTH_ORTHO_COLSPAN  3
+#define GYRORTH_OFFSET_ROWSPAN 3
+#define GYRORTH_OFFSET_COLSPAN 1
+
+
 /* CORRECTIONS DEPENDENCY CONTROL */
 #define TEMPIMU_CALIB_DEPENDENCY (CORR_ENBL_NONE)
 #define MAGIRON_CALIB_DEPENDENCY (CORR_ENBL_TEMPIMU)
 #define ACCORTH_CALIB_DEPENDENCY (CORR_ENBL_TEMPIMU)
 #define MAGMOT_CALIB_DEPENDENCY  (CORR_ENBL_TEMPIMU | CORR_ENBL_MAGIRON)
+#define GYRORTH_CALIB_DEPENDENCY (CORR_ENBL_TEMPIMU | CORR_ENBL_ACCORTH)
 
 /* clang-format off */
-typedef enum { typeMagmot = 0, typeMagiron, typeMotlin, typeAccorth, typeTempimu } calibType_t;
+typedef enum { typeMagmot = 0, typeMagiron, typeMotlin, typeAccorth, typeTempimu, typeGyrorth } calibType_t;
 
 
 typedef enum { accSwapXYZ = 0, accSwapXZY, accSwapYXZ, accSwapYZX, accSwapZXY, accSwapZYX } accSwap_t;
@@ -104,6 +115,11 @@ typedef struct {
 			float alfaAcc[3]; /* linear coefficients [(mm / s^2) / K] for temperature compensation for x/y/z accelerometer axis */
 			float alfaGyr[3]; /* linear coefficients [(mrad / s) / K] for temperature compensation for x/y/z gyroscope axis */
 		} tempimu;
+
+		struct {
+			matrix_t ortho;  /* 3x3 nonorthogonality parameters matrix */
+			matrix_t offset; /* 3x1 measurement offset matrix */
+		} gyrorth;
 	} params;
 } calib_data_t;
 

--- a/libs/sensc/corr.c
+++ b/libs/sensc/corr.c
@@ -386,17 +386,17 @@ static void corr_tempimu(sensor_event_t *accelEvt, sensor_event_t *gyroEvt)
 
 	if (accelEvt->accels.temp != 0) {
 		diff = ((float)accelEvt->accels.temp) / 1000 - corr_common.tempimu.params.tempimu.refTemp;
-		accelEvt->accels.accelX += diff * corr_common.tempimu.params.tempimu.alfaAcc[0];
-		accelEvt->accels.accelY += diff * corr_common.tempimu.params.tempimu.alfaAcc[1];
-		accelEvt->accels.accelZ += diff * corr_common.tempimu.params.tempimu.alfaAcc[2];
+		accelEvt->accels.accelX -= diff * corr_common.tempimu.params.tempimu.alfaAcc[0];
+		accelEvt->accels.accelY -= diff * corr_common.tempimu.params.tempimu.alfaAcc[1];
+		accelEvt->accels.accelZ -= diff * corr_common.tempimu.params.tempimu.alfaAcc[2];
 	}
 
 	/* Only correcting direct measurement, as dAngle is hard to correct without timestamps */
 	if (gyroEvt->gyro.temp != 0) {
 		diff = ((float)gyroEvt->gyro.temp) / 1000 - corr_common.tempimu.params.tempimu.refTemp;
-		gyroEvt->gyro.gyroX += diff * corr_common.tempimu.params.tempimu.alfaGyr[0];
-		gyroEvt->gyro.gyroY += diff * corr_common.tempimu.params.tempimu.alfaGyr[1];
-		gyroEvt->gyro.gyroZ += diff * corr_common.tempimu.params.tempimu.alfaGyr[2];
+		gyroEvt->gyro.gyroX -= diff * corr_common.tempimu.params.tempimu.alfaGyr[0];
+		gyroEvt->gyro.gyroY -= diff * corr_common.tempimu.params.tempimu.alfaGyr[1];
+		gyroEvt->gyro.gyroZ -= diff * corr_common.tempimu.params.tempimu.alfaGyr[2];
 	}
 }
 

--- a/libs/sensc/corr.c
+++ b/libs/sensc/corr.c
@@ -119,10 +119,10 @@ int corr_init(void)
 		return -1;
 	}
 
-	magironRet = calib_readFile(CALIB_PATH, typeMagiron, &corr_common.magiron);
-	magmotRet = calib_readFile(CALIB_PATH, typeMagmot, &corr_common.magmot);
-	accorthRet = calib_readFile(CALIB_PATH, typeAccorth, &corr_common.accorth);
-	tempimuRet = calib_readFile(CALIB_PATH, typeTempimu, &corr_common.tempimu);
+	magironRet = calib_dataInit(CALIB_PATH, typeMagiron, &corr_common.magiron);
+	magmotRet = calib_dataInit(CALIB_PATH, typeMagmot, &corr_common.magmot);
+	accorthRet = calib_dataInit(CALIB_PATH, typeAccorth, &corr_common.accorth);
+	tempimuRet = calib_dataInit(CALIB_PATH, typeTempimu, &corr_common.tempimu);
 
 	/* error checking */
 	if (magironRet != 0 || magmotRet != 0 || accorthRet != 0 || tempimuRet != 0) {

--- a/libs/sensc/corr.c
+++ b/libs/sensc/corr.c
@@ -315,3 +315,24 @@ void corr_accorth(sensor_event_t *accelEvt)
 	accelEvt->accels.accelY = MATRIX_DATA(&final, 1, 0);
 	accelEvt->accels.accelZ = MATRIX_DATA(&final, 2, 0);
 }
+
+
+void corr_tempimu(sensor_event_t *accelEvt, sensor_event_t *gyroEvt)
+{
+	float diff;
+
+	if (accelEvt->accels.temp != 0) {
+		diff = ((float)accelEvt->accels.temp) / 1000 - corr_common.tempimu.params.tempimu.refTemp;
+		accelEvt->accels.accelX += diff * corr_common.tempimu.params.tempimu.alfaAcc[0];
+		accelEvt->accels.accelY += diff * corr_common.tempimu.params.tempimu.alfaAcc[1];
+		accelEvt->accels.accelZ += diff * corr_common.tempimu.params.tempimu.alfaAcc[2];
+	}
+
+	/* Only correcting direct measurement, as dAngle is hard to correct without timestamps */
+	if (gyroEvt->gyro.temp != 0) {
+		diff = ((float)gyroEvt->gyro.temp) / 1000 - corr_common.tempimu.params.tempimu.refTemp;
+		gyroEvt->gyro.gyroX += diff * corr_common.tempimu.params.tempimu.alfaGyr[0];
+		gyroEvt->gyro.gyroY += diff * corr_common.tempimu.params.tempimu.alfaGyr[1];
+		gyroEvt->gyro.gyroZ += diff * corr_common.tempimu.params.tempimu.alfaGyr[2];
+	}
+}

--- a/libs/sensc/corr.c
+++ b/libs/sensc/corr.c
@@ -41,6 +41,7 @@ struct {
 	calib_data_t magmot;
 	calib_data_t magiron;
 	calib_data_t accorth;
+	calib_data_t tempimu;
 
 	/* for magmot correction */
 	FILE *pwmFiles[NUM_OF_MOTORS];
@@ -95,7 +96,7 @@ void corr_done(void)
 
 int corr_init(void)
 {
-	int magironRet, magmotRet, accorthRet;
+	int magironRet, magmotRet, accorthRet, tempimuRet;
 	int i;
 	bool err = false;
 
@@ -121,13 +122,15 @@ int corr_init(void)
 	magironRet = calib_readFile(CALIB_PATH, typeMagiron, &corr_common.magiron);
 	magmotRet = calib_readFile(CALIB_PATH, typeMagmot, &corr_common.magmot);
 	accorthRet = calib_readFile(CALIB_PATH, typeAccorth, &corr_common.accorth);
+	tempimuRet = calib_readFile(CALIB_PATH, typeTempimu, &corr_common.tempimu);
 
 	/* error checking */
-	if (magironRet != 0 || magmotRet != 0 || accorthRet != 0) {
+	if (magironRet != 0 || magmotRet != 0 || accorthRet != 0 || tempimuRet != 0) {
 
 		(magmotRet == 0) ? calib_free(&corr_common.magiron) : fprintf(stderr, "corr: magmot init failed\n");
 		(magironRet == 0) ? calib_free(&corr_common.magiron) : fprintf(stderr, "corr: magiron init failed\n");
 		(accorthRet == 0) ? calib_free(&corr_common.accorth) : fprintf(stderr, "corr: accorth init failed\n");
+		(tempimuRet == 0) ? calib_free(&corr_common.tempimu) : fprintf(stderr, "corr: tempimu init failed\n");
 
 		for (i = 0; i < NUM_OF_MOTORS; i++) {
 			fclose(corr_common.pwmFiles[i]);

--- a/libs/sensc/corr.h
+++ b/libs/sensc/corr.h
@@ -18,8 +18,12 @@
 #include <libsensors.h>
 
 
-/* Performs calibration on magnetometer data */
-void corr_mag(sensor_event_t *magEvt);
+/* Performs hard/soft iron calibration on magnetometer data */
+void corr_magiron(sensor_event_t *magEvt);
+
+
+/* Performs motors interference calibration */
+void corr_magmot(sensor_event_t *magEvt);
 
 
 /* Performs orthogonality calibration for accelerometer. Raw accelerometer data should be passed */

--- a/libs/sensc/corr.h
+++ b/libs/sensc/corr.h
@@ -33,6 +33,10 @@ void corr_accorth(sensor_event_t *accelEvt);
 void corr_accrot(sensor_event_t *accelEvt, sensor_event_t *gyroEvt, sensor_event_t *magEvt);
 
 
+/* Corrects temperature impact on IMU measurements */
+void corr_tempimu(sensor_event_t *accelEvt, sensor_event_t *gyroEvt);
+
+
 /* Deinitializes correction procedures */
 void corr_done(void);
 

--- a/libs/sensc/corr.h
+++ b/libs/sensc/corr.h
@@ -46,6 +46,6 @@ void corr_done(void);
 
 
 /* initializes all correction procedures. Returns 0 on success */
-int corr_init(void);
+int corr_init(int initFlags);
 
 #endif

--- a/libs/sensc/corr.h
+++ b/libs/sensc/corr.h
@@ -18,27 +18,7 @@
 #include <libsensors.h>
 
 
-/* Performs hard/soft iron calibration on magnetometer data */
-void corr_magiron(sensor_event_t *magEvt);
-
-
-/* Performs motors interference calibration */
-void corr_magmot(sensor_event_t *magEvt);
-
-
-/* Performs orthogonality calibration for accelerometer. Raw accelerometer data should be passed */
-void corr_accorth(sensor_event_t *accelEvt);
-
-
-/*
-* Performs initial data rotation based on accelerometer initial attitude quaternion.
-* Orthogonal calibrated data should be passed.
-*/
-void corr_accrot(sensor_event_t *accelEvt, sensor_event_t *gyroEvt, sensor_event_t *magEvt);
-
-
-/* Corrects temperature impact on IMU measurements */
-void corr_tempimu(sensor_event_t *accelEvt, sensor_event_t *gyroEvt);
+void corr_imu(sensor_event_t *accelEvt, sensor_event_t *gyroEvt, sensor_event_t *magEvt);
 
 
 /* Deinitializes correction procedures */

--- a/libs/sensc/sensc.c
+++ b/libs/sensc/sensc.c
@@ -126,11 +126,9 @@ int sensc_init(const char *path, int corrInitFlags, int sensInitFlags)
 	int err;
 
 	sensc_common.corrInitFlags = corrInitFlags;
-	if (sensc_common.corrInitFlags != CORR_ENBL_NONE) {
-		if (corr_init(CORR_ENBL_ALL) != 0) {
-			fprintf(stderr, "Cannot setup correction module\n");
-			return -1;
-		}
+	if (corr_init(corrInitFlags) != 0) {
+		fprintf(stderr, "Cannot setup correction module\n");
+		return -1;
 	}
 
 	err = 0;
@@ -144,9 +142,7 @@ int sensc_init(const char *path, int corrInitFlags, int sensInitFlags)
 		sensc_closeDescr(&sensc_common.fdBaro);
 		sensc_closeDescr(&sensc_common.fdGps);
 
-		if (sensc_common.corrInitFlags != CORR_ENBL_NONE) {
-			corr_done();
-		}
+		corr_done();
 		return -1;
 	}
 
@@ -160,9 +156,7 @@ void sensc_deinit(void)
 	sensc_closeDescr(&sensc_common.fdBaro);
 	sensc_closeDescr(&sensc_common.fdGps);
 
-	if (sensc_common.corrInitFlags != CORR_ENBL_NONE) {
-		corr_done();
-	}
+	corr_done();
 }
 
 

--- a/libs/sensc/sensc.c
+++ b/libs/sensc/sensc.c
@@ -127,7 +127,7 @@ int sensc_init(const char *path, bool corrEnable, int initFlags)
 
 	sensc_common.corrEnable = corrEnable;
 	if (sensc_common.corrEnable == true) {
-		if (corr_init() != 0) {
+		if (corr_init(CORR_ENBL_ALL) != 0) {
 			fprintf(stderr, "Cannot setup correction module\n");
 			return -1;
 		}

--- a/libs/sensc/sensc.c
+++ b/libs/sensc/sensc.c
@@ -39,7 +39,7 @@ struct {
 	int fdBaro;
 	int fdGps;
 
-	bool corrEnable;
+	int corrInitFlags;
 } sensc_common;
 
 
@@ -121,12 +121,12 @@ static int sensc_openDescr(const char *path, int typeFlag, int initFlags, int *s
 }
 
 
-int sensc_init(const char *path, bool corrEnable, int initFlags)
+int sensc_init(const char *path, int corrInitFlags, int sensInitFlags)
 {
 	int err;
 
-	sensc_common.corrEnable = corrEnable;
-	if (sensc_common.corrEnable == true) {
+	sensc_common.corrInitFlags = corrInitFlags;
+	if (sensc_common.corrInitFlags != CORR_ENBL_NONE) {
 		if (corr_init(CORR_ENBL_ALL) != 0) {
 			fprintf(stderr, "Cannot setup correction module\n");
 			return -1;
@@ -134,9 +134,9 @@ int sensc_init(const char *path, bool corrEnable, int initFlags)
 	}
 
 	err = 0;
-	err |= sensc_openDescr(path, SENSC_INIT_IMU, initFlags, &sensc_common.fdImu);
-	err |= sensc_openDescr(path, SENSC_INIT_BARO, initFlags, &sensc_common.fdBaro);
-	err |= sensc_openDescr(path, SENSC_INIT_GPS, initFlags, &sensc_common.fdGps);
+	err |= sensc_openDescr(path, SENSC_INIT_IMU, sensInitFlags, &sensc_common.fdImu);
+	err |= sensc_openDescr(path, SENSC_INIT_BARO, sensInitFlags, &sensc_common.fdBaro);
+	err |= sensc_openDescr(path, SENSC_INIT_GPS, sensInitFlags, &sensc_common.fdGps);
 
 	if (err != 0) {
 		fprintf(stderr, "sensc: init failed\n");
@@ -144,7 +144,7 @@ int sensc_init(const char *path, bool corrEnable, int initFlags)
 		sensc_closeDescr(&sensc_common.fdBaro);
 		sensc_closeDescr(&sensc_common.fdGps);
 
-		if (sensc_common.corrEnable == true) {
+		if (sensc_common.corrInitFlags != CORR_ENBL_NONE) {
 			corr_done();
 		}
 		return -1;
@@ -160,7 +160,7 @@ void sensc_deinit(void)
 	sensc_closeDescr(&sensc_common.fdBaro);
 	sensc_closeDescr(&sensc_common.fdGps);
 
-	if (sensc_common.corrEnable == true) {
+	if (sensc_common.corrInitFlags != CORR_ENBL_NONE) {
 		corr_done();
 	}
 }

--- a/libs/sensc/sensc.c
+++ b/libs/sensc/sensc.c
@@ -201,14 +201,8 @@ int sensc_imuGet(sensor_event_t *accelEvt, sensor_event_t *gyroEvt, sensor_event
 		}
 	}
 
-	if (sensc_common.corrEnable == true) {
-
-		corr_magiron(magEvt);
-		corr_magmot(magEvt);
-		corr_tempimu(accelEvt, gyroEvt);
-		corr_accorth(accelEvt);
-		corr_accrot(accelEvt, gyroEvt, magEvt); /* assumption: IMU returns data in the same frame of reference */
-	}
+	/* Corrections */
+	corr_imu(accelEvt, gyroEvt, magEvt);
 
 	return (flag == 0) ? 0 : -1;
 }

--- a/libs/sensc/sensc.c
+++ b/libs/sensc/sensc.c
@@ -203,7 +203,8 @@ int sensc_imuGet(sensor_event_t *accelEvt, sensor_event_t *gyroEvt, sensor_event
 
 	if (sensc_common.corrEnable == true) {
 
-		corr_mag(magEvt);
+		corr_magiron(magEvt);
+		corr_magmot(magEvt);
 		corr_tempimu(accelEvt, gyroEvt);
 		corr_accorth(accelEvt);
 		corr_accrot(accelEvt, gyroEvt, magEvt); /* assumption: IMU returns data in the same frame of reference */

--- a/libs/sensc/sensc.c
+++ b/libs/sensc/sensc.c
@@ -204,6 +204,7 @@ int sensc_imuGet(sensor_event_t *accelEvt, sensor_event_t *gyroEvt, sensor_event
 	if (sensc_common.corrEnable == true) {
 
 		corr_mag(magEvt);
+		corr_tempimu(accelEvt, gyroEvt);
 		corr_accorth(accelEvt);
 		corr_accrot(accelEvt, gyroEvt, magEvt); /* assumption: IMU returns data in the same frame of reference */
 	}

--- a/libs/sensc/sensc.h
+++ b/libs/sensc/sensc.h
@@ -23,6 +23,16 @@
 #define SENSC_INIT_GPS  (1 << 2)
 
 
+#define CORR_ENBL_MAGIRON (1 << 0)
+#define CORR_ENBL_MAGMOT  (1 << 1)
+#define CORR_ENBL_ACCORTH (1 << 2)
+#define CORR_ENBL_ACCROT  (1 << 3)
+#define CORR_ENBL_TEMPIMU (1 << 4)
+
+#define CORR_ENBL_ALL  (~(unsigned int)0)
+#define CORR_ENBL_NONE (0)
+
+
 /* initializes sensor client that should be accessible under path (e.g /dev/sensors) with option to turn on/off corrections module */
 extern int sensc_init(const char *path, bool corrEnable, int initFlags);
 

--- a/libs/sensc/sensc.h
+++ b/libs/sensc/sensc.h
@@ -28,6 +28,7 @@
 #define CORR_ENBL_ACCORTH (1 << 2)
 #define CORR_ENBL_ACCROT  (1 << 3)
 #define CORR_ENBL_TEMPIMU (1 << 4)
+#define CORR_ENBL_GYRORTH (1 << 5)
 
 #define CORR_ENBL_ALL  (~(unsigned int)0)
 #define CORR_ENBL_NONE (0)

--- a/libs/sensc/sensc.h
+++ b/libs/sensc/sensc.h
@@ -33,8 +33,13 @@
 #define CORR_ENBL_NONE (0)
 
 
-/* initializes sensor client that should be accessible under path (e.g /dev/sensors) with option to turn on/off corrections module */
-extern int sensc_init(const char *path, bool corrEnable, int initFlags);
+/*
+ *Iinitialize sensor client with:
+ * - sensorhub under `path` (e.g /dev/sensors)
+ * - corrections initialized according to `corrInitFlags`
+ * - sensors initialized according to `sensInitFlags
+ */
+extern int sensc_init(const char *path, int corrInitFlags, int sensInitFlags);
 
 /* deinitializes all initialized parts of sensor client */
 extern void sensc_deinit(void);

--- a/quadcontrol/mma.c
+++ b/quadcontrol/mma.c
@@ -145,7 +145,7 @@ int mma_init(const quad_coeffs_t *coeffs, const mma_atten_t *atten)
 {
 	int err;
 
-	if (calib_readFile(CALIB_PATH, typeMotlin, &mma_common.calib) != 0) {
+	if (calib_dataInit(CALIB_PATH, typeMotlin, &mma_common.calib) != 0) {
 		printf("mma: cannot initialize motlin calibration\n");
 		return -1;
 	}

--- a/utils/devekf.c
+++ b/utils/devekf.c
@@ -99,7 +99,7 @@ static inline void printUavAcc(ekf_state_t *uavState)
 	quat_vecRot(&aEarth, &qState);
 	aEarth.z += EARTH_G;
 
-	printf("YPR: %.1f %.2f %.2f E_ACC %.3f %.3f %.3f\n", uavState->yaw, uavState->pitch, uavState->roll, aEarth.x, aEarth.y, aEarth.z);
+	printf("YPR: %.1f %.2f %.2f E_ACC %.3f %.3f %.3f\n", uavState->yaw * 180 / 3.1415, uavState->pitch * 180 / 3.1415, uavState->roll * 180 / 3.1415, aEarth.x, aEarth.y, aEarth.z);
 }
 
 

--- a/utils/senslog.c
+++ b/utils/senslog.c
@@ -186,7 +186,7 @@ int main(int argc, char **argv)
 	fprintf(stdout, "Logging for %lli seconds with %llims step\n", senslog_common.diffMax / 1000000, senslog_common.step / 1000);
 
 	/* initialization of sensor client with selectable corrections (raw == true means corrections disabled) */
-	if (sensc_init("/dev/sensors", !senslog_common.raw, senslog_common.senscInitFlags) < 0) {
+	if (sensc_init("/dev/sensors", (senslog_common.raw) ? CORR_ENBL_NONE : CORR_ENBL_ALL, senslog_common.senscInitFlags) < 0) {
 		fprintf(stderr, "Cannot initialize sensor client\n");
 		return EXIT_FAILURE;
 	}

--- a/utils/sensortest.c
+++ b/utils/sensortest.c
@@ -152,7 +152,7 @@ int main(int argc, char **argv)
 		return EXIT_FAILURE;
 	}
 
-	if (sensc_init("/dev/sensors", false, SENSC_INIT_IMU | SENSC_INIT_BARO | SENSC_INIT_GPS) < 0) {
+	if (sensc_init("/dev/sensors", CORR_ENBL_NONE, SENSC_INIT_IMU | SENSC_INIT_BARO | SENSC_INIT_GPS) < 0) {
 		printf("cannot initialize sensor client\n");
 		return EXIT_FAILURE;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
 - adding imu temperature calibration `tempiumu`
 - correction module more modular
 - correction module initialization flags

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Adding `tempimu` calibration type forced a change in `sensc` and `corr` so that it is possible to run only selected calibrations and corrections. It is because `tempimu` calibration must be applied on non-calirbated data and current `accorth` calibration must be done on `tempimu` calibrated data, yet it is no possible to do these calibrations together. 

This problem occurs also with `magiron`/`magmot` calibrations and `accorth`/`accrot` but there it was mitigated by joining calibration procedures. However to tidy it up these calibrations will need splitting and the correct order of calibration enforced in `calibtool` with `corrInitFlags`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: zturn drone

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
