### PR TITLE
ekf: source selection flag unification

### DIFF
--- a/ekf/ekflib.c
+++ b/ekf/ekflib.c
@@ -114,7 +114,7 @@ static int ekf_measGate(int initFlags)
 			 * and data source from `ekf.conf` is equal to SENSORS.
 			 */
 
-			if ((initFlags & EKF_INIT_SENC_SCR) == 0) {
+			if ((initFlags & EKF_INIT_LOG_SRC) != 0) {
 				fprintf(stderr, "Ekf config: inconsistent data source specifiers\n");
 				return -1;
 			}
@@ -207,6 +207,8 @@ int ekf_init(int initFlags)
 		kalman_updateDealloc(&ekf_common.imuEngine);
 		kalman_updateDealloc(&ekf_common.baroEngine);
 		kalman_updateDealloc(&ekf_common.gpsEngine);
+
+		return -1;
 	}
 
 	if (ekflog_writerInit(EKF_LOG_FILE, ekf_common.initVals.log | ekf_common.initVals.logMode) != 0) {

--- a/ekf/ekflib.h
+++ b/ekf/ekflib.h
@@ -15,9 +15,7 @@
 #define EKFLIB_H
 
 /* Ekf init flags */
-#define EKF_INIT_SENC_SCR (1 << 0) /* Sets sensors as input data for EKF */
-#define EKF_INIT_LOG_SRC  (1 << 1) /* Sets logs as input data for EKF */
-
+#define EKF_INIT_LOG_SRC (1 << 0) /* Sets logs as input data for EKF */
 
 /* Ekf status flags */
 #define EKF_STATUS_RUNNING (1 << 0)

--- a/planecontrol/control.c
+++ b/planecontrol/control.c
@@ -85,7 +85,7 @@ static int plane_init(void)
 	}
 
 	/* EKF initialization */
-	if (ekf_init(EKF_INIT_SENC_SCR) < 0) {
+	if (ekf_init(0) < 0) {
 		fprintf(stderr, "planecontrol: cannot initialize ekf\n");
 		return -1;
 	}

--- a/quadcontrol/control.c
+++ b/quadcontrol/control.c
@@ -1004,7 +1004,7 @@ static int quad_init(void)
 	}
 
 	/* EKF initialization */
-	if (ekf_init(EKF_INIT_SENC_SCR) < 0) {
+	if (ekf_init(0) < 0) {
 		fprintf(stderr, "quadcontrol: cannot initialize ekf\n");
 		resourceDestroy(quad_common.rcbusLock);
 		free(quad_common.scenario);

--- a/utils/devekf.c
+++ b/utils/devekf.c
@@ -137,7 +137,7 @@ int main(int argc, char **argv)
 
 	printf("Press 'q' and confirm with enter to exit\n");
 
-	if (ekf_init(EKF_INIT_LOG_SRC | EKF_INIT_SENC_SCR) != 0) {
+	if (ekf_init(EKF_INIT_LOG_SRC) != 0) {
 		fprintf(stderr, "devekf: error during ekf init\n");
 		return EXIT_FAILURE;
 	}

--- a/utils/sensortest.c
+++ b/utils/sensortest.c
@@ -182,7 +182,7 @@ int main(int argc, char **argv)
 		return EXIT_FAILURE;
 	}
 
-	if (ekf_init(EKF_INIT_LOG_SRC | EKF_INIT_SENC_SCR) != 0) {
+	if (ekf_init(EKF_INIT_LOG_SRC) != 0) {
 		printf("Cannot initialize ekf\n");
 		sensortest_motorsClose();
 		return EXIT_FAILURE;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Currently there are two flags that specify the data source for measurements: `EKF_INIT_SENC_SCR` and `EKF_INIT_LOG_SRC` and it is unclear what happens if both are up. This PR reduces flags to single one, which decides the source for EKF.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Clearer interface

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here). `host-generic-pilot`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
