### PR TITLE
ekflog: fix issue with checking if `size_t` is less than zero

### DIFF
--- a/ekf/logs/reader.c
+++ b/ekf/logs/reader.c
@@ -39,7 +39,7 @@ static void ekflog_ebadfMsg(void)
 }
 
 
-static int ekflog_logSizeGet(char logIndicator)
+static ssize_t ekflog_logSizeGet(char logIndicator)
 {
 	switch (logIndicator) {
 		case TIME_LOG_INDICATOR:
@@ -66,8 +66,8 @@ static int ekflog_logSizeGet(char logIndicator)
 
 static int ekflog_logOmit(char logIndicator)
 {
-	const size_t prefixLen = LOG_ID_SIZE + LOG_IDENTIFIER_SIZE; /* Without the timestamp */
-	size_t logSize = ekflog_logSizeGet(logIndicator);
+	const ssize_t prefixLen = LOG_ID_SIZE + LOG_IDENTIFIER_SIZE; /* Without the timestamp */
+	ssize_t logSize = ekflog_logSizeGet(logIndicator);
 	if (logSize < 0) {
 		return -1;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Previously we tried to use `size_t` as signed type, which is incorrect. This PR fixes that with type change to `ssize_t`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes incorrect variable usage.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here). `host-generic-pilot`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
