### PR TITLE
devekf hotfix

### DIFF
--- a/utils/devekf.c
+++ b/utils/devekf.c
@@ -190,6 +190,7 @@ int main(int argc, char **argv)
 		ekf_stateGet(&uavState);
 
 		if (handleUavStatus(uavState.status) != 0) {
+			pthread_cancel(keyboardHandlerTID);
 			break;
 		}
 
@@ -208,7 +209,6 @@ int main(int argc, char **argv)
 		/* Mode = silent do not invoke any printing function */
 	}
 
-	pthread_cancel(keyboardHandlerTID);
 	pthread_join(keyboardHandlerTID, NULL);
 
 	ekf_stop();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
This PR fixes `devekf`, which was not closing after exiting with `q` key. It turns out that our `pthread_cancel` in `libphoenix` does not returns then it is called to cancel thread, which waits for join.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Robust and pleasant tools to work with.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here). `armv7a9-zynq7000-vpilot`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
