### PR TITLE
ekflib: conform to new building script

### DIFF
--- a/ekf/Makefile
+++ b/ekf/Makefile
@@ -13,11 +13,6 @@ LOCAL_SRCS := ekflib.c $(KALMAN_SRCS) meas.c filters.c logs/writer.c logs/reader
 LOCAL_HEADERS := ekflib.h
 DEPS := libalgeb libsensc libcalib libparser libhmap
 
-# Additional compilation flag for pthreads is needed if host target is compiling
-ifeq ("$(TARGET)","host-generic-pilot")
-	LOCAL_LDFLAGS := -lpthread
-endif
-
 ifeq ("$(LOG_VOL_CHECK)","TRUE")
 	LOCAL_CFLAGS := -DLOG_VOL_CHECK
 	LOCAL_SRCS += logs/max_logs.c


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Removes variables from Makefile that are not recognized by `static-lib.mk` while compiling for host.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ability do build ekf for host

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here). `host-generic-pilot`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
