### PR TITLE
Fix calculating calibration vector length on every iteration

### DIFF
--- a/ekf/meas.c
+++ b/ekf/meas.c
@@ -364,8 +364,9 @@ int meas_imuCalib(void)
 	vec_times(&gyrAvg, 1. / (float)avg);
 	vec_times(&magAvg, 1. / (float)avg);
 
-	meas_common.calib.imu.gyroBias = gyrAvg; /* save gyro drift parameters */
-	meas_common.calib.imu.initMag = magAvg;  /* save initial magnetometer reading */
+	meas_common.calib.imu.gyroBias = gyrAvg;             /* save gyro drift parameters */
+	meas_common.calib.imu.initMag = magAvg;              /* save initial magnetometer reading */
+	meas_common.calib.imu.initMagLen = vec_len(&magAvg); /* save initial magnetic vector length */
 
 	/* calculate initial rotation */
 	vec_normalize(&accAvg);

--- a/ekf/meas.h
+++ b/ekf/meas.h
@@ -46,8 +46,11 @@ typedef struct {
 typedef struct {
 	struct {
 		quat_t initQuat; /* starting position quaternion */
-		vec_t initMag;   /* starting magnetic field */
-		vec_t gyroBias;  /* starting gyro bias */
+
+		vec_t initMag;    /* starting magnetic field */
+		float initMagLen; /* length of starting magnetic field vector */
+
+		vec_t gyroBias; /* starting gyro bias */
 	} imu;
 
 	struct {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Previously during imu measurement normalization length of magnetic vector from calibration was calculated during every iteration. This PR fixes that.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Faster EKF iterations

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here). `host-generic-pilot`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
